### PR TITLE
Fix basename support in middlware and link hrefs

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -13,13 +13,14 @@ export default class Link extends Component {
   }
 
   render() {
+    const { href, history, children} = this.props;
     return (
       <a
         {...this.props}
-        href={this.props.href}
+        href={history ? history.createHref(href) : href}
         onClick={this.onClick.bind(this)}
       >
-        {this.props.children}
+        {children}
       </a>
     );
   }
@@ -28,5 +29,6 @@ export default class Link extends Component {
 Link.propTypes = {
   href: PropTypes.string,
   children: PropTypes.node,
-  dispatch: PropTypes.func
+  dispatch: PropTypes.func,
+  history: PropTypes.object
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,9 +3,11 @@ import {
 } from './action-types';
 
 const locationDidChange = location => {
+  const { basename, pathname } = location;
   return {
     type: LOCATION_CHANGED,
-    payload: location.pathname
+    payload: `${basename || ''}${pathname}`
+      .replace(/\/$/, '') // remove trailing slash
   };
 };
 


### PR DESCRIPTION
Links weren't generating correct `href`s when using a basename. The basename also got omitted from the pathname in the state tree. Link now accepts a `history` prop to allow use of `history.createHref`.