### PR TITLE
Add previous URL info to router state

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "coveralls": "^2.11.9",
-    "feather-route-matcher": "^2.0.1",
     "history": "^3.0.0-2",
     "rimraf": "^2.5.2",
+    "url-pattern": "^1.0.1",
     "webpack": "^1.12.15"
   },
   "devDependencies": {

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -1,0 +1,18 @@
+import UrlPattern from 'url-pattern';
+
+export default routes => {
+  const routeCache = Object.keys(routes).map(key => ({
+    pattern: new UrlPattern(key),
+    result: routes[key]
+  }));
+
+  return incomingRoute => {
+    const match = routeCache.find(
+      route => route.pattern.match(incomingRoute)
+    );
+    return {
+      params: match.pattern.match(incomingRoute),
+      result: match.result
+    };
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ import createStoreWithRouter from './store-enhancer';
 import routerMiddleware from './middleware';
 import routerReducer from './reducer';
 import Link from './link';
+import createMatcher from './create-matcher';
 
 export {
   createStoreWithRouter,
   routerMiddleware,
   routerReducer,
-  Link
+  Link,
+  createMatcher
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,5 @@
 import { LOCATION_CHANGED } from './action-types';
-import { default as matcherFactory } from 'feather-route-matcher';
+import { default as matcherFactory } from './create-matcher';
 
 export default (routes, createMatcher = matcherFactory) => {
   const matchRoute = createMatcher(routes);
@@ -7,7 +7,11 @@ export default (routes, createMatcher = matcherFactory) => {
   return (state = {}, action) => {
     if (action.type === LOCATION_CHANGED) {
       return {
-        ...matchRoute(action.payload.url),
+        current: {
+          ...matchRoute(action.payload.url),
+          url: action.payload.url
+        },
+        previous: state.current,
         historyAction: action.payload.action
       };
     }

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -1,5 +1,5 @@
 import { applyMiddleware } from 'redux';
-import { default as matcherFactory } from 'feather-route-matcher';
+import { default as matcherFactory } from './create-matcher';
 
 import routerReducer from './reducer';
 import routerMiddleware from './middleware';

--- a/test/spec/reducer.spec.jsx
+++ b/test/spec/reducer.spec.jsx
@@ -3,7 +3,8 @@ import { LOCATION_CHANGED } from 'src/action-types';
 
 const mockCreateMatcher = () => () => {
   return {
-    pathname: '/rofl'
+    params: {},
+    result: 'rofl'
   };
 };
 
@@ -17,8 +18,14 @@ describe('Router reducer', () => {
       }
     };
     const result = routerReducer({}, mockCreateMatcher)({}, action);
+
     expect(result).to.deep.equal({
-      pathname: '/rofl',
+      current: {
+        params: {},
+        result: 'rofl',
+        url: '/rofl'
+      },
+      previous: undefined,
       historyAction: 'PUSH'
     });
   });

--- a/test/spec/store-enhancer.spec.jsx
+++ b/test/spec/store-enhancer.spec.jsx
@@ -7,7 +7,8 @@ import MockHistory from './mocks/history';
 
 const mockCreateMatcher = () => () => {
   return {
-    pathname: '/changed'
+    params: {},
+    result: 'changed'
   };
 };
 
@@ -38,7 +39,7 @@ describe('Router store enhancer', () => {
     store.subscribe(() => {
       const state = store.getState();
       expect(state).to.have.deep.property(
-        'router.pathname', '/changed'
+        'router.current.result', 'changed'
       );
       done();
     });
@@ -60,7 +61,7 @@ describe('Router store enhancer', () => {
     store.subscribe(() => {
       const state = store.getState();
       expect(state).to.have.deep.property(
-        'router.pathname', '/changed'
+        'router.current.result', 'changed'
       );
       done();
     });


### PR DESCRIPTION
Change router state payload to include previous and current url info; replace feather-route-matcher with url-pattern and a small wrapper.

This is a breaking change.