### PR TITLE
Replace native find with lodash find for older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-preset-stage-2": "^6.5.0",
     "coveralls": "^2.11.9",
     "history": "^3.0.0-2",
+    "lodash.find": "^4.3.0",
     "rimraf": "^2.5.2",
     "url-pattern": "^1.0.1",
     "webpack": "^1.12.15"

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -1,4 +1,5 @@
 import UrlPattern from 'url-pattern';
+import find from 'lodash.find';
 
 export default routes => {
   const routeCache = Object.keys(routes).map(key => ({
@@ -7,8 +8,8 @@ export default routes => {
   }));
 
   return incomingRoute => {
-    const match = routeCache.find(
-      route => route.pattern.match(incomingRoute)
+    const match = find(routeCache, route =>
+      route.pattern.match(incomingRoute)
     );
     return {
       params: match.pattern.match(incomingRoute),

--- a/test/spec/create-matcher.spec.jsx
+++ b/test/spec/create-matcher.spec.jsx
@@ -1,0 +1,55 @@
+import { createMatcher } from 'src';
+
+const routes = {
+  '/home': {
+    name: 'home'
+  },
+  '/home/messages': {
+    name: 'messages'
+  },
+  '/home/messages/:team': {
+    name: 'team'
+  },
+  '/home/messages/:team/:channel': {
+    name: 'channel'
+  }
+};
+
+describe('createMatcher', () => {
+  it('matches URLs and returns both their params and their value in the route hash', () => {
+    const matchRoute = createMatcher(routes);
+
+    expect(matchRoute('/home')).to.deep.equal({
+      params: {},
+      result: {
+        name: 'home'
+      }
+    });
+
+    expect(matchRoute('/home/messages')).to.deep.equal({
+      params: {},
+      result: {
+        name: 'messages'
+      }
+    });
+
+    expect(matchRoute('/home/messages/a-team')).to.deep.equal({
+      params: {
+        team: 'a-team'
+      },
+      result: {
+        name: 'team'
+      }
+    });
+
+    expect(matchRoute('/home/messages/a-team/the-wat-channel')).to.deep.equal({
+      params: {
+        team: 'a-team',
+        channel: 'the-wat-channel'
+      },
+      result: {
+        name: 'channel'
+      }
+    });
+  });
+});


### PR DESCRIPTION
Also adds tests for `createMatcher` where the failure occurred.