### PR TITLE
Prevent crash on bad route

### DIFF
--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -10,10 +10,11 @@ export default routes => {
   return incomingRoute => {
     const match = find(routeCache, route =>
       route.pattern.match(incomingRoute)
-    );
-    return {
+    ) || null;
+
+    return match ? {
       params: match.pattern.match(incomingRoute),
       result: match.result
-    };
+    } : null;
   };
 };


### PR DESCRIPTION
This causes a 500 error on SSR when URLs like `xxx/ordering/` fail to match.