### PR TITLE
Changes for v3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,14 @@ import routerMiddleware from './middleware';
 import routerReducer from './reducer';
 import Link from './link';
 import createMatcher from './create-matcher';
-import { LOCATION_CHANGED } from './action-types';
+import {
+  LOCATION_CHANGED,
+  PUSH,
+  REPLACE,
+  GO,
+  GO_FORWARD,
+  GO_BACK
+} from './action-types';
 
 export {
   createStoreWithRouter,
@@ -11,5 +18,10 @@ export {
   routerReducer,
   Link,
   createMatcher,
-  LOCATION_CHANGED
+  LOCATION_CHANGED,
+  PUSH,
+  REPLACE,
+  GO,
+  GO_FORWARD,
+  GO_BACK
 };

--- a/src/link.js
+++ b/src/link.js
@@ -1,11 +1,13 @@
 import React, { Component, PropTypes } from 'react';
-import { PUSH } from './action-types';
+import { PUSH, REPLACE } from './action-types';
 
 export default class Link extends Component {
   onClick(event) {
     event.preventDefault();
-    this.props.dispatch({
-      type: PUSH,
+    const { replaceState, dispatch } = this.props;
+
+    dispatch({
+      type: replaceState ? REPLACE : PUSH,
       payload: {
         pathname: this.props.href
       }
@@ -13,7 +15,7 @@ export default class Link extends Component {
   }
 
   render() {
-    const { href, history, children} = this.props;
+    const { href, history, children } = this.props;
     return (
       <a
         {...this.props}
@@ -30,5 +32,6 @@ Link.propTypes = {
   href: PropTypes.string,
   children: PropTypes.node,
   dispatch: PropTypes.func,
-  history: PropTypes.object
+  history: PropTypes.object,
+  replaceState: PropTypes.bool
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,11 +3,12 @@ import {
 } from './action-types';
 
 const locationDidChange = location => {
-  const { basename, pathname, action } = location;
+  const { basename, pathname, action, state } = location;
   return {
     type: LOCATION_CHANGED,
     payload: {
       action,
+      state,
       url: `${basename || ''}${pathname}`
         .replace(/\/$/, '') // remove trailing slash
     }
@@ -28,13 +29,13 @@ export default history => {
 
     switch (action.type) {
       case PUSH:
-        history.push(action.payload.pathname);
+        history.push(action.payload);
         break;
       case REPLACE:
-        history.replace(action.payload.pathname);
+        history.replace(action.payload);
         break;
       case GO:
-        history.go(action.payload.index);
+        history.go(action.payload);
         break;
       case GO_BACK:
         history.goBack();

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -9,10 +9,9 @@ export default (routes, createMatcher = matcherFactory) => {
       return {
         current: {
           ...matchRoute(action.payload.url),
-          url: action.payload.url
+          ...action.payload
         },
-        previous: state.current,
-        historyAction: action.payload.action
+        previous: state.current
       };
     }
     return state;

--- a/test/spec/link.spec.jsx
+++ b/test/spec/link.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { PUSH } from 'src/action-types';
+import { PUSH, REPLACE } from 'src/action-types';
 import Link from 'src/link';
 
 describe('Router link component', () => {
@@ -17,6 +17,22 @@ describe('Router link component', () => {
     };
     const wrapper = mount(
       <Link dispatch={dispatch} href='/yo' />
+    );
+    wrapper.find('a').simulate('click');
+  });
+
+  it('dispatches a REPLACE action with the correct href when clicked', done => {
+    const dispatch = action => {
+      expect(action).to.deep.equal({
+        type: REPLACE,
+        payload: {
+          pathname: '/yo'
+        }
+      });
+      done();
+    };
+    const wrapper = mount(
+      <Link replaceState dispatch={dispatch} href='/yo' />
     );
     wrapper.find('a').simulate('click');
   });

--- a/test/spec/middleware.spec.jsx
+++ b/test/spec/middleware.spec.jsx
@@ -49,11 +49,14 @@ describe('Router middleware', () => {
   Object.keys(actions).forEach(actionType => {
     const expected = actions[actionType];
 
-    it(`dispatches location changes with ${actionType}`, done => {
+    it(`dispatches location changes with ${actionType} and associated state`, done => {
       const action = {
         type: actionType,
         payload: {
-          pathname: expected.url
+          pathname: expected.url,
+          state: {
+            bork: 'bork'
+          }
         }
       };
       testRouterMiddleware(action, done, resultAction => {
@@ -61,7 +64,10 @@ describe('Router middleware', () => {
           type: LOCATION_CHANGED,
           payload: {
             url: expected.url,
-            action: expected.action
+            action: expected.action,
+            state: {
+              bork: 'bork'
+            }
           }
         });
       });

--- a/test/spec/mocks/history.js
+++ b/test/spec/mocks/history.js
@@ -10,35 +10,50 @@ export default class MockHistory {
   push() {
     this.callback({
       pathname: '/push',
-      action: 'PUSH'
+      action: 'PUSH',
+      state: {
+        bork: 'bork'
+      }
     });
   }
 
   replace() {
     this.callback({
       pathname: '/replace',
-      action: 'REPLACE'
+      action: 'REPLACE',
+      state: {
+        bork: 'bork'
+      }
     });
   }
 
   go() {
     this.callback({
       pathname: '/go',
-      action: 'REPLACE'
+      action: 'REPLACE',
+      state: {
+        bork: 'bork'
+      }
     });
   }
 
   goBack() {
     this.callback({
       pathname: '/goBack',
-      action: 'POP'
+      action: 'POP',
+      state: {
+        bork: 'bork'
+      }
     });
   }
 
   goForward() {
     this.callback({
       pathname: '/goForward',
-      action: 'PUSH'
+      action: 'PUSH',
+      state: {
+        bork: 'bork'
+      }
     });
   }
 }

--- a/test/spec/reducer.spec.jsx
+++ b/test/spec/reducer.spec.jsx
@@ -14,7 +14,10 @@ describe('Router reducer', () => {
       type: LOCATION_CHANGED,
       payload: {
         url: '/rofl',
-        action: 'PUSH'
+        action: 'PUSH',
+        state: {
+          bork: 'bork'
+        }
       }
     };
     const result = routerReducer({}, mockCreateMatcher)({}, action);
@@ -23,10 +26,13 @@ describe('Router reducer', () => {
       current: {
         params: {},
         result: 'rofl',
-        url: '/rofl'
+        url: '/rofl',
+        action: 'PUSH',
+        state: {
+          bork: 'bork'
+        }
       },
-      previous: undefined,
-      historyAction: 'PUSH'
+      previous: undefined
     });
   });
 


### PR DESCRIPTION
- Expose almost all of the API as public. This allows consumers to hook into the history cycle using the newly exported action types (LOCATION_CHANGED, REPLACE, etc).
- Handle `history`'s `state` field for location-specific state.
- The action creators now take the same arguments as their equivalent `history` functions (either a pathname string or a full location descriptor object).
- `<Link>` now has an optional `replaceState` prop. When true, `<Link>` will dispatch a replace action instead of a push.
- Removed the unused `historyAction` field. This is a breaking change.