### PR TITLE
Initial location action plus more useful LOCATION_CHANGED actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import createStoreWithRouter from './store-enhancer';
-import routerMiddleware from './middleware';
+import routerMiddleware, { locationDidChange } from './middleware';
 import routerReducer from './reducer';
 import Link from './link';
 import createMatcher from './create-matcher';
@@ -18,6 +18,7 @@ export {
   routerReducer,
   Link,
   createMatcher,
+  locationDidChange,
   LOCATION_CHANGED,
   PUSH,
   REPLACE,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,8 +4,9 @@ import {
 
 export const locationDidChange = ({ location, matchRoute }) => {
   const { basename, pathname, action, state } = location;
+  const trailingSlash = /\/$/;
   const url = `${basename || ''}${pathname}`
-    .replace(/\/$/, ''); // remove trailing slash
+    .replace(trailingSlash, '');
 
   return {
     type: LOCATION_CHANGED,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,51 +2,61 @@ import {
   LOCATION_CHANGED, PUSH, REPLACE, GO, GO_BACK, GO_FORWARD
 } from './action-types';
 
-const locationDidChange = location => {
+export const locationDidChange = ({ location, matchRoute }) => {
   const { basename, pathname, action, state } = location;
+  const url = `${basename || ''}${pathname}`
+    .replace(/\/$/, ''); // remove trailing slash
+
   return {
     type: LOCATION_CHANGED,
     payload: {
+      ...matchRoute(url),
       action,
       state,
-      url: `${basename || ''}${pathname}`
-        .replace(/\/$/, '') // remove trailing slash
+      url
     }
   };
 };
 
-let locationListener;
+export const initializeCurrentLocation = location => ({
+  type: LOCATION_CHANGED,
+  payload: location
+});
 
-export default history => {
-  return () => next => action => {
-    if (!locationListener) {
-      locationListener = history.listen(location => {
-        if (location) {
-          next(locationDidChange(location));
+export default ({ history, matchRoute }) => {
+  return ({ dispatch }) => {
+    history.listen(location => {
+      if (location) {
+        dispatch(locationDidChange({
+          location, matchRoute
+        }));
+      }
+    });
+
+    return next => action => {
+      switch (action.type) {
+        case PUSH:
+          history.push(action.payload);
+          break;
+        case REPLACE:
+          history.replace(action.payload);
+          break;
+        case GO:
+          history.go(action.payload);
+          break;
+        case GO_BACK:
+          history.goBack();
+          break;
+        case GO_FORWARD:
+          history.goForward();
+          break;
+        case LOCATION_CHANGED: {
+          next(action);
+          break;
         }
-      });
-    }
-
-    switch (action.type) {
-      case PUSH:
-        history.push(action.payload);
-        break;
-      case REPLACE:
-        history.replace(action.payload);
-        break;
-      case GO:
-        history.go(action.payload);
-        break;
-      case GO_BACK:
-        history.goBack();
-        break;
-      case GO_FORWARD:
-        history.goForward();
-        break;
-      case LOCATION_CHANGED:
-        break;
-      default:
-        next(action);
-    }
+        default:
+          next(action);
+      }
+    };
   };
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,19 +1,19 @@
 import { LOCATION_CHANGED } from './action-types';
-import { default as matcherFactory } from './create-matcher';
 
-export default (routes, createMatcher = matcherFactory) => {
-  const matchRoute = createMatcher(routes);
-
-  return (state = {}, action) => {
-    if (action.type === LOCATION_CHANGED) {
-      return {
-        current: {
-          ...matchRoute(action.payload.url),
-          ...action.payload
-        },
-        previous: state.current
-      };
+export default (state = {}, action) => {
+  if (action.type === LOCATION_CHANGED) {
+    // No-op the initial route action
+    if (
+      state.current &&
+      state.current.url === action.payload.url
+    ) {
+      return state;
     }
-    return state;
-  };
+
+    return {
+      current: {...action.payload},
+      previous: state.current
+    };
+  }
+  return state;
 };

--- a/test/spec/middleware.spec.jsx
+++ b/test/spec/middleware.spec.jsx
@@ -1,10 +1,20 @@
 /* eslint-env mocha */
 import { routerMiddleware } from 'src';
+import createMatcher from 'src/create-matcher';
+
 import {
   LOCATION_CHANGED, PUSH, REPLACE, GO, GO_BACK, GO_FORWARD
 } from 'src/action-types';
 
 import MockHistory from './mocks/history';
+
+const fakeRoutes = {
+  '/push': 'push',
+  '/replace': 'replace',
+  '/go': 'go',
+  '/goBack': 'goBack',
+  '/goForward': 'goForward'
+};
 
 const testRouterMiddleware = (initialAction, done, assertion) => {
   const didDispatch = action => {
@@ -14,7 +24,10 @@ const testRouterMiddleware = (initialAction, done, assertion) => {
   const doDispatch = action => didDispatch(action);
   const doGetState = () => {};
 
-  const nextHandler = routerMiddleware(new MockHistory())({
+  const nextHandler = routerMiddleware({
+    history: new MockHistory(),
+    matchRoute: createMatcher(fakeRoutes)
+  })({
     dispatch: doDispatch,
     getState: doGetState
   })(doDispatch);
@@ -26,23 +39,28 @@ describe('Router middleware', () => {
   const actions = {
     [PUSH]: {
       url: '/push',
-      action: 'PUSH'
+      action: 'PUSH',
+      result: 'push'
     },
     [REPLACE]: {
       url: '/replace',
-      action: 'REPLACE'
+      action: 'REPLACE',
+      result: 'replace'
     },
     [GO]: {
       url: '/go',
-      action: 'REPLACE'
+      action: 'REPLACE',
+      result: 'go'
     },
     [GO_BACK]: {
       url: '/goBack',
-      action: 'POP'
+      action: 'POP',
+      result: 'goBack'
     },
     [GO_FORWARD]: {
       url: '/goForward',
-      action: 'PUSH'
+      action: 'PUSH',
+      result: 'goForward'
     }
   };
 
@@ -64,7 +82,9 @@ describe('Router middleware', () => {
           type: LOCATION_CHANGED,
           payload: {
             url: expected.url,
+            params: {},
             action: expected.action,
+            result: expected.result,
             state: {
               bork: 'bork'
             }

--- a/test/spec/reducer.spec.jsx
+++ b/test/spec/reducer.spec.jsx
@@ -1,18 +1,13 @@
 import { routerReducer } from 'src';
 import { LOCATION_CHANGED } from 'src/action-types';
 
-const mockCreateMatcher = () => () => {
-  return {
-    params: {},
-    result: 'rofl'
-  };
-};
-
 describe('Router reducer', () => {
   it('adds the pathname to the store', () => {
     const action = {
       type: LOCATION_CHANGED,
       payload: {
+        params: {},
+        result: 'rofl',
         url: '/rofl',
         action: 'PUSH',
         state: {
@@ -20,7 +15,7 @@ describe('Router reducer', () => {
         }
       }
     };
-    const result = routerReducer({}, mockCreateMatcher)({}, action);
+    const result = routerReducer({}, action);
 
     expect(result).to.deep.equal({
       current: {
@@ -43,7 +38,7 @@ describe('Router reducer', () => {
         crazy: 'nonsense'
       }
     };
-    const result = routerReducer({}, mockCreateMatcher)({}, action);
+    const result = routerReducer({}, action);
     expect(result).to.deep.equal({});
   });
 });

--- a/test/spec/store-enhancer.spec.jsx
+++ b/test/spec/store-enhancer.spec.jsx
@@ -12,11 +12,10 @@ const mockCreateMatcher = () => () => {
   };
 };
 
-const storeWithMiddleware = middleware => {
+const storeWithMiddleware = (middleware, initialState = {}) => {
   const reducer = state => {
     return {...state, hello: 'world' };
   };
-  const initialState = {};
 
   return createStore(
     reducer,


### PR DESCRIPTION
- If there is initial state for the router, dispatch a LOCATION_CHANGED event so that anything dependent on the URL can guarantee to be in sync with the router.
- `createMatcher` now applies directly to actions within the middleware instead of within the reducer. This gives LOCATION_CHANGED richer details and allows consumers to plan for location-dependent side effects without requiring introspection of the state tree.