### PR TITLE
Fix duplicate basenames in hrefs; avoid matching against full URL

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -5,13 +5,16 @@ const Fragment = (props, context) => {
   const { forRoute, forRoutes, withConditions, children } = props;
   const { router: location } = context.router.store.getState();
 
-  if (forRoute && !new UrlPattern(forRoute).match(location.url)) {
+  if (
+    forRoute &&
+    !new UrlPattern(forRoute).match(location.pathname)
+  ) {
     return null;
   }
 
   if (forRoutes) {
     const anyMatch = forRoutes.some(route =>
-      new UrlPattern(route).match(location.url)
+      new UrlPattern(route).match(location.pathname)
     );
 
     if (!anyMatch) {

--- a/src/link.js
+++ b/src/link.js
@@ -4,6 +4,9 @@ import { PUSH, REPLACE } from './action-types';
 
 const LEFT_MOUSE_BUTTON = 0;
 
+const normalizeHref = location =>
+  `${location.basename || ''}${location.pathname}`;
+
 const normalizeLocation = href => {
   if (typeof href === 'string') {
     const [pathname, query] = href.split('?');
@@ -74,7 +77,7 @@ const Link = (props, context) => {
     <a
       className={props.className}
       style={props.style}
-      href={router.history.createHref(location)}
+      href={normalizeHref(location)}
       onClick={e => onClick({
         e,
         target,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,7 +3,7 @@ import { LOCATION_CHANGED } from './action-types';
 export default (state = {}, action) => {
   if (action.type === LOCATION_CHANGED) {
     // No-op the initial route action
-    if (state && state.url === action.payload.url) {
+    if (state && state.pathname === action.payload.pathname) {
       return state;
     }
 

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -5,6 +5,7 @@ import routerReducer from './reducer';
 
 export const locationDidChange = ({ location, matchRoute }) => {
   // Build the canonical URL
+  // Don't use this for matching
   const { basename, pathname } = location;
   const trailingSlash = /\/$/;
   const url = `${basename || ''}${pathname}`
@@ -14,7 +15,7 @@ export const locationDidChange = ({ location, matchRoute }) => {
     type: LOCATION_CHANGED,
     payload: {
       ...location,
-      ...matchRoute(url),
+      ...matchRoute(pathname),
       url
     }
   };

--- a/test/spec/reducer.spec.jsx
+++ b/test/spec/reducer.spec.jsx
@@ -9,6 +9,7 @@ describe('Router reducer', () => {
         params: {},
         result: 'rofl',
         url: '/rofl',
+        pathname: '/rofl',
         action: 'PUSH',
         state: {
           bork: 'bork'
@@ -21,6 +22,7 @@ describe('Router reducer', () => {
       params: {},
       result: 'rofl',
       url: '/rofl',
+      pathname: '/rofl',
       action: 'PUSH',
       state: {
         bork: 'bork'


### PR DESCRIPTION
`history.createHref()` adds duplicate basenames to the `href` (https://github.com/ReactTraining/history/issues/169). This solves that.

When matching routes, we matched against `url` instead of `pathname`, which ended up forcing you to hard-code basenames in your routes. This fixes that too!