### PR TITLE
Remove all lodash methods and remove array spread

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-2": "^6.11.0",
     "coveralls": "^2.11.11",
-    "exenv": "^1.2.1",
     "history": "^3.0.0",
-    "lodash.assign": "^4.0.9",
-    "lodash.find": "^4.4.0",
     "rimraf": "^2.5.3",
     "url-pattern": "^1.0.1",
     "webpack": "^1.13.1"

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -1,5 +1,4 @@
 import UrlPattern from 'url-pattern';
-import find from 'lodash.find';
 
 export default routes => {
   const routeDictionary = Object.keys(routes).map(route => ({
@@ -10,18 +9,25 @@ export default routes => {
 
   return incomingUrl => {
     // Discard query strings
-    const [route, , ] = incomingUrl.split('?');
+    const route = incomingUrl.split('?')[0]; // eslint-disable-line no-magic-numbers
 
     // Find the route that matches the URL
-    const match = find(routeDictionary, storedRoute =>
-      storedRoute.pattern.match(route)
-    );
+    for (const key in routeDictionary) {
+      if (routeDictionary.hasOwnProperty(key)) {
+        const storedRoute = routeDictionary[key];
+        const match = storedRoute.pattern.match(route);
 
-    // Return the matched params and user-defined result object
-    return match ? {
-      route: match.route,
-      params: match.pattern.match(route),
-      result: match.result
-    } : null;
+        if (match) {
+          // Return the matched params and user-defined result object
+          return {
+            route: storedRoute.route,
+            params: match,
+            result: storedRoute.result
+          };
+        }
+      }
+    }
+
+    return null;
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import createStoreWithRouter, {
   locationDidChange,
   initializeCurrentLocation
 } from './store-enhancer';
-import initialRouterState from './initial-router-state';
 
 import provideRouter from './provider';
 import { Link, PersistentQueryLink } from './link';
@@ -23,7 +22,6 @@ import {
 export {
   // High-level Redux API
   createStoreWithRouter,
-  initialRouterState,
   initializeCurrentLocation,
 
   // React API

--- a/src/initial-router-state.js
+++ b/src/initial-router-state.js
@@ -1,16 +1,14 @@
 import createMatcher from './create-matcher';
-import assign from 'lodash.assign';
 
 export default ({
   pathname = '/',
   query = {},
   routes,
   history
-}) =>
-  assign({},
-    history.createLocation({
-      pathname,
-      query
-    }),
-    createMatcher(routes)(pathname)
-  );
+}) => ({
+  ...history.createLocation({
+    pathname,
+    query
+  }),
+  ...createMatcher(routes)(pathname)
+});

--- a/src/link.js
+++ b/src/link.js
@@ -9,7 +9,9 @@ const normalizeHref = location =>
 
 const normalizeLocation = href => {
   if (typeof href === 'string') {
-    const [pathname, query] = href.split('?');
+    const pathnameAndQuery = href.split('?');
+    const pathname = pathnameAndQuery[0]; // eslint-disable-line no-magic-numbers
+    const query = pathnameAndQuery[1]; // eslint-disable-line no-magic-numbers
     return query ? { pathname, search: `?${query}` } : { pathname };
   }
   return href;

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -67,7 +67,8 @@ export default ({
 
       // Support redux-loop
       if (Array.isArray(newState)) {
-        const [nextState, nextEffects] = newState;
+        const nextState = newState[0]; // eslint-disable-line no-magic-numbers
+        const nextEffects = newState[1]; // eslint-disable-line no-magic-numbers
         return [
           {
             ...nextState,


### PR DESCRIPTION
Apparently array spread requires the `Symbol` polyfill:
https://babeljs.io/docs/usage/caveats/

We don't want that!