### PR TITLE
Change default basename from '/' to empty string

### DIFF
--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -49,7 +49,7 @@ export default ({
   routes,
   pathname,
   query,
-  basename = '/',
+  basename = '',
   forServerRender = false,
   createMatcher = matcherFactory,
   history: userHistory


### PR DESCRIPTION
Setting basename to '/' prevents routes with a leading '/' from matching. For example, `<Fragment forRoute="/test" />` will throw an exception when the user navigates to `hostname/test`.