### PR TITLE
Allow usage of either an HoC or a component for providing router context

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Alternatively, you can pass in a [location descriptor](https://github.com/ReactT
 
 `<Link>` takes an optional valueless prop, `replaceState`, that changes the link navigation behavior from `pushState` to `replaceState` in the History API.
 
-### `provideRouter`
+### `provideRouter` or `<RouterProvider>`
 
 Like React Router's `<Provider>`, you'll want to wrap `provideRouter` around your app's top-level component like so:
 
@@ -249,6 +249,24 @@ ReactDOM.render(<AppComponentWithRouter />, document.getElementById('root');
 ```
 
 This allows `<Fragment>` and `<Link>` to obtain their `history` and `dispatch` instances without manual prop passing.
+
+If you'd rather use a plain component instead of a higher-ordered component, use `<RouterProvider>` like so:
+
+```es6
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { RouterProvider } from 'redux-little-router';
+import YourAppComponent from './';
+
+import createYourStore from './state';
+
+ReactDOM.render(
+  <RouterProvider store={createYourStore()}>
+    <YourComponent />
+  </RouterProvider>
+  document.getElementById('root');
+)
+```
 
 ## Environment
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import createStoreWithRouter, {
   initializeCurrentLocation
 } from './store-enhancer';
 
-import provideRouter from './provider';
+import provideRouter, { RouterProvider } from './provider';
 import { Link, PersistentQueryLink } from './link';
 import Fragment from './fragment';
 
@@ -26,6 +26,7 @@ export {
 
   // React API
   provideRouter,
+  RouterProvider,
   Link,
   PersistentQueryLink,
   Fragment,

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,31 +1,34 @@
 import React, { Component, PropTypes } from 'react';
 
-export default ({ store }) => ComposedComponent => {
-  class RouterProvider extends Component {
-    constructor(props) {
-      super(props);
-      this.router = { store };
-    }
-
-    getChildContext() {
-      return {
-        router: this.router
-      };
-    }
-
-    render() {
-      const { children, ...rest } = this.props; // eslint-disable-line no-unused-vars
-      return <ComposedComponent {...rest} />;
-    }
+export class RouterProvider extends Component {
+  constructor(props) {
+    super(props);
+    this.router = {
+      store: props.store
+    };
   }
 
-  RouterProvider.childContextTypes = {
-    router: PropTypes.object
-  };
+  getChildContext() {
+    return {
+      router: this.router
+    };
+  }
 
-  RouterProvider.propTypes = {
-    children: PropTypes.node
-  };
+  render() {
+    return this.props.children;
+  }
+}
 
-  return RouterProvider;
+RouterProvider.childContextTypes = {
+  router: PropTypes.object
 };
+
+RouterProvider.propTypes = {
+  children: PropTypes.node,
+  store: PropTypes.object
+};
+
+export default ({ store }) => ComposedComponent => props =>
+  <RouterProvider store={store}>
+    <ComposedComponent {...props} />
+  </RouterProvider>;

--- a/test/provider.spec.js
+++ b/test/provider.spec.js
@@ -3,29 +3,55 @@ import { mount } from 'enzyme';
 
 import React, { Component, PropTypes } from 'react';
 
-import provideRouter from '../src/provider';
+import provideRouter, { RouterProvider } from '../src/provider';
 
 import { fakeStore } from './util';
 
-describe('provideRouter', () => {
-  it('adds router context to a child tree', () => {
-    class MagicalMysteryComponent extends Component {
-      render() {
-        const state = this.context.router.store.getState();
-        return <div>{state.router.pathname}</div>;
+describe('Router provider', () => {
+  describe('provideRouter HoC', () => {
+    it('adds router context to a child tree', () => {
+      class MagicalMysteryComponent extends Component {
+        render() {
+          const state = this.context.router.store.getState();
+          return <div>{state.router.pathname}</div>;
+        }
       }
-    }
 
-    MagicalMysteryComponent.contextTypes = {
-      router: PropTypes.object
-    };
+      MagicalMysteryComponent.contextTypes = {
+        router: PropTypes.object
+      };
 
-    const MagicalMysteryRouter = provideRouter({
-      store: fakeStore()
-    })(MagicalMysteryComponent);
+      const MagicalMysteryRouter = provideRouter({
+        store: fakeStore()
+      })(MagicalMysteryComponent);
 
-    const wrapper = mount(<MagicalMysteryRouter />);
-    const div = wrapper.find('div');
-    expect(div.node.textContent).to.equal('/home/messages/b-team');
+      const wrapper = mount(<MagicalMysteryRouter />);
+      const div = wrapper.find('div');
+      expect(div.node.textContent).to.equal('/home/messages/b-team');
+    });
+  });
+
+  describe('RouterProvider component', () => {
+    it('adds router context to a child tree', () => {
+      class MagicalMysteryComponent extends Component {
+        render() {
+          const state = this.context.router.store.getState();
+          return <div>{state.router.pathname}</div>;
+        }
+      }
+
+      MagicalMysteryComponent.contextTypes = {
+        router: PropTypes.object
+      };
+
+      const wrapper = mount(
+        <RouterProvider store={fakeStore()}>
+          <MagicalMysteryComponent />
+        </RouterProvider>
+      );
+
+      const div = wrapper.find('div');
+      expect(div.node.textContent).to.equal('/home/messages/b-team');
+    });
   });
 });


### PR DESCRIPTION
There's interest in using a regular component as an alternative to the higher-ordered component `provideRouter`  in #19. This PR adds that component.

Before:

```js
const componentWithRouter = provideRouter({ store })(YourComponent);
```

After:

```js
// Either the HoC:
const componentWithRouter = provideRouter({ store })(YourComponent);

// Or the plain component:
const elementWithRouter = (
  <RouterProvider store={store}>
    <YourComponent />
  </RouterProvider>
);
```