### PR TITLE
Allow DOM props to pass through Link to the actual a tag

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -85,7 +85,8 @@ const Link = (
     target,
     persistQuery,
     replaceState,
-    children
+    children,
+    ...rest
   } = props;
 
   const { router } = context;
@@ -102,8 +103,6 @@ const Link = (
 
   return (
     <a
-      className={props.className}
-      style={props.style}
       href={normalizeHref(location)}
       onClick={e => onClick({
         e,
@@ -112,6 +111,7 @@ const Link = (
         replaceState,
         router
       })}
+      {...rest}
     >
       {children}
     </a>

--- a/test/link.spec.js
+++ b/test/link.spec.js
@@ -173,6 +173,35 @@ describe('Router link component', () => {
 
         expect(spy).to.have.been.calledOnce;
       });
+
+      it('passes through DOM props, including aria attributes', () => {
+        const fakeNewLocation = {
+          pathname: '/home/things',
+          search: '',
+          action: 'PUSH',
+          query: {}
+        };
+
+        const wrapper = shallow(
+          <Link
+            href='/home/things'
+            aria-label='a11y'
+            className='classy'
+            style={{
+              fontFamily: 'Comic Sans'
+            }}
+          />,
+          fakeContext({ fakeNewLocation })
+        );
+
+        const props = wrapper.props();
+        expect(props).to.have.property('aria-label', 'a11y');
+        expect(props).to.have.property('className', 'classy');
+        expect(props).to.have.property('style')
+          .that.deep.equals({
+            fontFamily: 'Comic Sans'
+          });
+      });
     });
   });
 


### PR DESCRIPTION
Not sure why I didn't do this before, but now all DOM props (including ARIA attributes) work on `<Link>`, not just `className` and `style`.

/cc @divmain @baer 