### PR TITLE
Remove postinstall

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+.nyc_output/
+config/
+coverage/
+src/
+test/
+.babelrc
+.editorconfig
+.eslintrc
+.flowconfig
+.babelrc
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,4 @@ script:
   - npm run check-cov
   - node_modules/.bin/nyc report --reporter=text-lcov | node_modules/.bin/coveralls || echo "Coveralls upload failed"
 
-  # Prune deps to just production and peerDeps and ensure we can still build
-  - npm prune --production
-
-  # Peer dependencies again
-  - npm install redux@^3.0.0 react@^15.0.0-0 react-dom@^15.0.0-0
-
   - npm run build

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "homepage": "https://github.com/FormidableLabs/redux-little-router#readme",
   "dependencies": {
     "history": "^3.0.0",
+    "rimraf": "^2.5.3",
     "url-pattern": "^1.0.1"
   },
   "devDependencies": {
@@ -75,7 +76,6 @@
     "redux-logger": "^2.6.1",
     "redux-loop": "^2.2.2",
     "redux-thunk": "^2.1.0",
-    "rimraf": "^2.5.3",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "watch": "^0.19.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "homepage": "https://github.com/FormidableLabs/redux-little-router#readme",
   "dependencies": {
     "history": "^3.0.0",
-    "rimraf": "^2.5.3",
     "url-pattern": "^1.0.1"
   },
   "devDependencies": {
@@ -76,6 +75,7 @@
     "redux-logger": "^2.6.1",
     "redux-loop": "^2.2.2",
     "redux-thunk": "^2.1.0",
+    "rimraf": "^2.5.3",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "watch": "^0.19.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A barebones routing solution for Redux applications.",
   "main": "lib/index.js",
   "scripts": {
-    "postinstall": "cd lib || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",
@@ -39,25 +38,23 @@
   },
   "homepage": "https://github.com/FormidableLabs/redux-little-router#readme",
   "dependencies": {
+    "history": "^3.0.0",
+    "url-pattern": "^1.0.1"
+  },
+  "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.11.3",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-2": "^6.11.0",
-    "coveralls": "^2.11.11",
-    "history": "^3.0.0",
-    "rimraf": "^2.5.3",
-    "url-pattern": "^1.0.1",
-    "webpack": "^1.13.1"
-  },
-  "devDependencies": {
     "babel-eslint": "^6.1.2",
     "babel-plugin-istanbul": "^1.0.3",
     "babel-polyfill": "^6.9.1",
     "babel-preset-react-hmre": "^1.1.1",
     "chai": "^3.5.0",
     "concurrently": "^2.2.0",
+    "coveralls": "^2.11.11",
     "enzyme": "^2.4.1",
     "eslint": "^3.0.1",
     "eslint-config-defaults": "^10.0.0-alpha.1",
@@ -78,9 +75,11 @@
     "redux-logger": "^2.6.1",
     "redux-loop": "^2.2.2",
     "redux-thunk": "^2.1.0",
+    "rimraf": "^2.5.3",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "watch": "^0.19.1",
+    "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Getting some strange results on `postinstall` after adding Flow annotations:

```
src/action-types.js -> lib/action-types.js
src/create-matcher.js -> lib/create-matcher.js
src/fragment.js -> lib/fragment.js
src/index.js -> lib/index.js
src/initial-router-state.js -> lib/initial-router-state.js
src/link.js -> lib/link.js
SyntaxError: src/provider.js: Missing class properties transform.
 12 | 
 13 | export class RouterProvider extends Component {
> 14 |   router: { store: Store };
    |   ^
 15 | 
 16 |   constructor(props: Props) {
 17 |     super(props);
```

A full `rm -rf node_modules && npm install` confirms that the transform _is_ present and fixes the issue.

Moving to `prepublish` so we don't have to worry about `postinstall` issues anymore.