### PR TITLE
ensure Fragment returns null if can't match any routes

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -18,20 +18,24 @@ const Fragment = (
   }
 ) => {
   const { forRoute, forRoutes, withConditions, children } = props;
-  const { store } = context.router;
-  const { matchRoute } = store;
-  const { router: location } = store.getState();
+  const { matchRoute } = context.router.store;
+  const { router: location } = context.router.store.getState();
+  const matchResult = matchRoute(location.pathname);
+
+  if (!matchResult) {
+    return null;
+  }
 
   if (
     forRoute &&
-    matchRoute(location.pathname).route !== forRoute
+    matchResult.route !== forRoute
   ) {
     return null;
   }
 
   if (forRoutes) {
     const anyMatch = forRoutes.some(route =>
-      matchRoute(location.pathname).route === route
+      matchResult.route === route
     );
 
     if (!anyMatch) {

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -35,6 +35,18 @@ describe('Fragment', () => {
     expect(wrapper.find('p')).to.have.lengthOf(0);
   });
 
+  it('renders nothing if the current URL does not match any of the routes', () => {
+    const wrapper = mount(
+      <Fragment forRoute='/home'>
+        <p>Nothing to see here!</p>
+      </Fragment>,
+      fakeContext({
+        pathname: '/homeFake'
+      })
+    );
+    expect(wrapper.find('p')).to.have.lengthOf(0);
+  });
+
   const multiRoutes = [
     '/home/messages/:team/:channel',
     '/home/messages/:team',


### PR DESCRIPTION
`matchRoute(location.pathname)` can return null and if `fragment.js` were to evaluate `matchRoute(location.pathname).route` it would result in an unhandled exception.