### PR TITLE
Throw when routes are empty or malformed

### DIFF
--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -28,6 +28,11 @@ import { default as matcherFactory } from './create-matcher';
 import routerReducer from './reducer';
 import initialRouterState from './initial-router-state';
 
+const README_MESSAGE = `
+  See the README for more information:
+  https://github.com/FormidableLabs/redux-little-router#wiring-up-the-boilerplate
+`;
+
 type LocationDidChangeArgs = {
   location: Location,
   matchRoute: Function
@@ -86,6 +91,26 @@ export default ({
   createMatcher = matcherFactory,
   history: userHistory
 }: StoreEnhancerArgs) => {
+  if (!routes) {
+    throw Error(`
+      Missing route configuration. You must define your routes as
+      an object where the keys are routes and the values are any
+      route-specific data.
+
+      ${README_MESSAGE}
+    `);
+  }
+
+  // eslint-disable-next-line no-magic-numbers
+  if (!Object.keys(routes).every(route => route.indexOf('/') === 0)) {
+    throw Error(`
+      The route configuration you provided is malformed. Make sure
+      that all of your routes start with a slash.
+
+      ${README_MESSAGE}
+    `);
+  }
+
   const history = userHistory || resolveHistory({
     basename, forServerRender
   });

--- a/test/store-enhancer.spec.js
+++ b/test/store-enhancer.spec.js
@@ -15,7 +15,7 @@ import createStoreWithRouter, {
   initializeCurrentLocation
 } from '../src/store-enhancer';
 
-import routes from './fixtures/routes';
+import defaultRoutes from './fixtures/routes';
 
 chai.use(sinonChai);
 
@@ -34,6 +34,7 @@ const defaultFakeInitialState = {
 
 const fakeStore = ({
   initialState = defaultFakeInitialState,
+  routes = defaultRoutes,
   useHistoryStub = true,
   isLoop = false,
   enhancerOptions = {}
@@ -81,6 +82,22 @@ const fakeStore = ({
 };
 
 describe('Router store enhancer', () => {
+  it('throws if no routes are provided', () => {
+    expect(() => fakeStore({
+      routes: null
+    })).to.throw(Error);
+  });
+
+  it('throws if malformed routes are provided', () => {
+    expect(() => fakeStore({
+      routes: {
+        'jlshdkfjgh': {},
+        '/real-route': {},
+        'w': 'tf'
+      }
+    })).to.throw(Error);
+  });
+
   it('updates the pathname in the state tree after dispatching history actions', done => {
     const { store } = fakeStore();
 


### PR DESCRIPTION
Adds some basic sanity checks for route configurations passed in to the store enhancer. Throws errors with some informational messages when the routes are empty or malformed (e.g. they don't all start with a slash).

/cc @baer @kriuz