### PR TITLE
Automatically connect() in RouterProvider to subscribe to state updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - npm --version
 
   # Peer dependencies
-  - npm install redux@^3.0.0 react@^15.0.0-0 react-dom@^15.0.0-0
+  - npm install redux@^3.0.0 react@^15.0.0-0 react-dom@^15.0.0-0 react-redux@^4.0.0
 
   - npm run check-cov
   - node_modules/.bin/nyc report --reporter=text-lcov | node_modules/.bin/coveralls || echo "Coveralls upload failed"

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ Your custom reducers or selectors can derive a large portion of your app's state
 - A `<Link>` component that sends navigation actions to the middleware when tapped or clicked. `<Link>` respects default modifier key and right-click behavior. A sibling component, `<PersistentQueryLink>`, persists the existing query string on navigation
 - A `provideRouter` HOC that passes down everything `<Fragment>` and `<Link>` need via context.
 
-`redux-little-router` assumes and requires that `react-redux` is installed for any of your components that consume `<Fragment>` or `<Link>`. You can access the router state using `react-redux`'s `connect()`:
+`redux-little-router` assumes and requires that your root component is wrapped in `<Provider>` from  `react-redux`. Both `provideRouter` and `<RouterProvider>` automatically `connect()` to updates from the router state.
+
+You can inspect the router state in any child component by using `connect()`:
 
 ```js
 export default connect(state => ({

--- a/package.json
+++ b/package.json
@@ -83,9 +83,10 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "redux": "^3.0.0",
     "react": "^0.14.0 || ^15.0.0-0",
-    "react-dom": "^0.14.0 || ^15.0.0-0"
+    "react-dom": "^0.14.0 || ^15.0.0-0",
+    "redux": "^3.0.0",
+    "react-redux": "^4.0.0"
   },
   "nyc": {
     "sourceMap": false,

--- a/src/provider.js
+++ b/src/provider.js
@@ -2,6 +2,7 @@
 import type { Store } from 'redux';
 
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 export type RouterContext = { store: Store };
 
@@ -10,7 +11,7 @@ type Props = {
   children: ReactPropTypes.node
 };
 
-export class RouterProvider extends Component {
+class RouterProviderImpl extends Component {
   router: { store: Store };
 
   constructor(props: Props) {
@@ -31,13 +32,17 @@ export class RouterProvider extends Component {
   }
 }
 
-RouterProvider.childContextTypes = {
+RouterProviderImpl.childContextTypes = {
   router: PropTypes.object
 };
 
 type ProvideRouterArgs = {
   store: Object
 };
+
+export const RouterProvider = connect(state => ({
+  router: state.router
+}))(RouterProviderImpl);
 
 export default ({ store }: ProvideRouterArgs) =>
   (ComposedComponent: ReactClass<*>) => (props: Object) =>

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -27,6 +27,10 @@ export const fakeStore = ({
   }
 
   return {
+    subscribe() {
+
+    },
+
     getState() {
       return {
         router: {


### PR DESCRIPTION
It's no longer required to manually `connect()` to get `<Link>` and `<Fragment>` rerenders working!

Resolves #38 

/cc @baer 