### PR TITLE
Nested Routing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,4 @@
 ---
-extends:
-  - "defaults/configurations/walmart/es6-react"
 
 parser: "babel-eslint"
 
@@ -10,7 +8,7 @@ plugins:
   - "flowtype"
 
 rules:
-  filenames/filenames: [2, "^[a-z\\-\\.]+$"] # dash-cased filenames.
+  # filenames/filenames: [2, "^[a-z\\-\\.]+$"] # dash-cased filenames.
   quotes:              [2, "single"]
   spaced-comment: [2, "always"]
   indent: [2, 2, {"SwitchCase": 1}]
@@ -29,4 +27,3 @@ env:
 ecmaFeatures:
   module: true
   modules: true
-

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -1,32 +1,107 @@
 // @flow
 import UrlPattern from 'url-pattern';
 
+
+
 export default (routes: Object) => {
-  const routeList = Object.keys(routes).map(route => ({
-    route,
-    pattern: new UrlPattern(route),
-    result: routes[route]
-  }));
+  // const routeList = Object.keys(routes).map(route => ({
+  //   route,
+  //   pattern: new UrlPattern(route),
+  //   result: routes[route]
+  // }));
+
+
+  // build the route list, but do it recursively
+  // const routeList = new Map();
+  // const traverseRoutes = (route, parentPath) => {
+  //   const path = `${parentPath}/${route.route}`;
+  //   const children = route.children;
+  //   routeList.set(path, route);
+  //   if (children) {
+  //     for (const child of children) {
+  //       traverseRoutes(child, path);
+  //     }
+  //   }
+  // };
+
+
 
   return (incomingUrl: string) => {
+
     // Discard query strings
     const route = incomingUrl.split('?')[0]; // eslint-disable-line no-magic-numbers
 
-    // Find the route that matches the URL
-    for (let i = 0; i < routeList.length; i++) {
-      const storedRoute = routeList[i];
-      const match = storedRoute.pattern.match(route);
-
+    const traverseRoutes = (toMatch, routeComponent, parentPath='') => {
+      const path = parentPath === '/' ? `/${routeComponent.route}` : `${parentPath}/${routeComponent.route || ''}`;
+      const pattern = new UrlPattern(path);
+      const match = pattern.match(toMatch);
       if (match) {
-        // Return the matched params and user-defined result object
-        return {
-          route: storedRoute.route,
+        return [{
+          route: path,
           params: match,
-          result: storedRoute.result
-        };
+          routeComponent
+        }];
       }
+
+      const children = routeComponent.children;
+      if (children) {
+        for (const child of children) {
+          const result = traverseRoutes(toMatch, child, path);
+          if (result) {
+            return [routeComponent].concat(result)
+          }
+        }
+      }
+    };
+
+    // Returns an array where the final index contains an object containing
+    // the route, matched params and the routeComponents. All other indicies
+    // contain just the routeComponents
+    const matchedRoute = traverseRoutes(route, routes);
+
+    if (!matchedRoute) {
+      return null;
     }
 
-    return null;
+    const finalRouteComponent = matchedRoute[matchedRoute.length-1];
+    return {
+      route: finalRouteComponent.route,
+      result: (matchedRoute.slice(0,-1).concat(finalRouteComponent.routeComponent)).map(r => {
+        const childlessR = Object.assign({}, r);
+        delete childlessR.children;
+        return childlessR
+      }),
+      params: finalRouteComponent.params
+    };
+
+    // Currently Output:
+    // {
+    //   route: The route which has actually been matched,
+    //   params: Any parameters (or empy object) that have been matched,
+    //   results: The extra information from the route details
+    // }
+    // TODO Output the following:
+    // {
+    //   route: The route which has actually been matched,
+    //   params: Any parameters (or empty object) that have been matched,
+    //   result: The tree components involved in this route
+    // }
+
+    // // Find the route that matches the URL
+    // for (let i = 0; i < routeList.length; i++) {
+    //   const storedRoute = routeList[i];
+    //   const match = storedRoute.pattern.match(route);
+    //
+    //   if (match) {
+    //     // Return the matched params and user-defined result object
+    //     return {
+    //       route: storedRoute.route,
+    //       params: match,
+    //       result: storedRoute.result
+    //     };
+    //   }
+    // }
+    //
+    // return null;
   };
 };

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -1,30 +1,8 @@
 // @flow
 import UrlPattern from 'url-pattern';
-
-
+import { join as pathJoin } from 'path';
 
 export default (routes: Object) => {
-  // const routeList = Object.keys(routes).map(route => ({
-  //   route,
-  //   pattern: new UrlPattern(route),
-  //   result: routes[route]
-  // }));
-
-
-  // build the route list, but do it recursively
-  // const routeList = new Map();
-  // const traverseRoutes = (route, parentPath) => {
-  //   const path = `${parentPath}/${route.route}`;
-  //   const children = route.children;
-  //   routeList.set(path, route);
-  //   if (children) {
-  //     for (const child of children) {
-  //       traverseRoutes(child, path);
-  //     }
-  //   }
-  // };
-
-
 
   return (incomingUrl: string) => {
 
@@ -32,23 +10,26 @@ export default (routes: Object) => {
     const route = incomingUrl.split('?')[0]; // eslint-disable-line no-magic-numbers
 
     const traverseRoutes = (toMatch, routeComponent, parentPath='') => {
-      const path = parentPath === '/' ? `/${routeComponent.route}` : `${parentPath}/${routeComponent.route || ''}`;
-      const pattern = new UrlPattern(path);
-      const match = pattern.match(toMatch);
-      if (match) {
-        return [{
-          route: path,
-          params: match,
-          routeComponent
-        }];
-      }
 
-      const children = routeComponent.children;
-      if (children) {
-        for (const child of children) {
-          const result = traverseRoutes(toMatch, child, path);
-          if (result) {
-            return [routeComponent].concat(result)
+      if (routeComponent.routeComponent) {
+        const path = pathJoin(parentPath, routeComponent.routeComponent);
+        const pattern = new UrlPattern(path);
+        const match = pattern.match(toMatch);
+        if (match) {
+          return [{
+            route: path,
+            params: match,
+            routeComponent
+          }];
+        }
+
+        const children = routeComponent.children;
+        if (children) {
+          for (const child of children) {
+            const result = traverseRoutes(toMatch, child, path);
+            if (result) {
+              return [routeComponent].concat(result)
+            }
           }
         }
       }
@@ -64,6 +45,14 @@ export default (routes: Object) => {
     }
 
     const finalRouteComponent = matchedRoute[matchedRoute.length-1];
+
+    // Return:
+    // {
+    //   route: The route which has actually been matched,
+    //   params: Any parameters (or empty object) that have been matched,
+    //   result: The tree components involved in this route
+    // }
+
     return {
       route: finalRouteComponent.route,
       result: (matchedRoute.slice(0,-1).concat(finalRouteComponent.routeComponent)).map(r => {
@@ -74,34 +63,5 @@ export default (routes: Object) => {
       params: finalRouteComponent.params
     };
 
-    // Currently Output:
-    // {
-    //   route: The route which has actually been matched,
-    //   params: Any parameters (or empy object) that have been matched,
-    //   results: The extra information from the route details
-    // }
-    // TODO Output the following:
-    // {
-    //   route: The route which has actually been matched,
-    //   params: Any parameters (or empty object) that have been matched,
-    //   result: The tree components involved in this route
-    // }
-
-    // // Find the route that matches the URL
-    // for (let i = 0; i < routeList.length; i++) {
-    //   const storedRoute = routeList[i];
-    //   const match = storedRoute.pattern.match(route);
-    //
-    //   if (match) {
-    //     // Return the matched params and user-defined result object
-    //     return {
-    //       route: storedRoute.route,
-    //       params: match,
-    //       result: storedRoute.result
-    //     };
-    //   }
-    // }
-    //
-    // return null;
   };
 };

--- a/src/fragment.js
+++ b/src/fragment.js
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
 type Props = {
   forRoute: string,
   forRoutes: [string],
+  inRoute: string,
   withConditions: (location: Location) => bool,
   children: ReactPropTypes.node
 };
@@ -17,7 +18,7 @@ const Fragment = (
     router: RouterContext
   }
 ) => {
-  const { forRoute, forRoutes, withConditions, children } = props;
+  const { forRoute, forRoutes, inRoute, withConditions, children } = props;
   const { store } = context.router;
   const { matchRoute } = store;
   const { router: location } = store.getState();
@@ -37,6 +38,13 @@ const Fragment = (
     if (!anyMatch) {
       return null;
     }
+  }
+
+  if (
+    inRoute &&
+    matchRoute(location.pathname).result.every(r => r.routeComponent !== inRoute)
+  ) {
+    return null;
   }
 
   if (withConditions && !withConditions(location)) {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ import {
   GO_BACK
 } from './action-types';
 
+import {
+  makeRoute
+} from './util';
+
 export {
   // High-level Redux API
   createStoreWithRouter,
@@ -43,5 +47,8 @@ export {
   // Low-level Redux utilities
   routerReducer,
   locationDidChange,
-  createMatcher
+  createMatcher,
+
+  // Route utilities
+  makeRoute
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
 // @flow
-export function makeRoute(details, ...children) {
+export function makeRoute(details: Object, ...children: Array<Object>) {
   return Object.assign({}, details, children ? { children } : {});
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,4 @@
+// @flow
+export function makeRoute(details, ...children) {
+  return Object.assign({}, details, children ? { children } : {});
+}

--- a/test.js
+++ b/test.js
@@ -1,11 +1,12 @@
 const UrlPattern = require('url-pattern');
+const pathJoin = require('path').join;
 
-const root = { name:'root' };
-const home = { route:'home', name:'home' };
-const messages = { route:'messages', name:'home' };
-const team = { route:':team', name:'team' };
-const channel = { route:':channel', name:'channel' };
-const spookyparam = { route:'spookyparam', name:'3spooky5me' };
+const root = { routeComponent: '/', name:'root' };
+const home = { routeComponent:'home', name:'home' };
+const messages = { routeComponent:'messages', name:'messages' };
+const team = { routeComponent:':team', name:'team' };
+const channel = { routeComponent:':channel', name:'channel' };
+const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
 
 const routes = Object.assign(root, {
   children: [Object.assign(home, {
@@ -13,25 +14,28 @@ const routes = Object.assign(root, {
       children: [Object.assign(team, {
         children: [Object.assign(channel, {})]
       })]
-    })]
-  }), Object.assign(spookyparam, {})]
+    }), Object.assign(spookyparam, {})]
+  })]
 });
 
-// Instead of building a flat route list, recursively match
-const traverseRoutes = (toMatch, route, parentPath='') => {
-  const path = parentPath === '/' ? `/${route.route}` : `${parentPath}/${route.route || ''}`;
+const traverseRoutes = (toMatch, routeComponent, parentPath='') => {
+  const path = pathJoin(parentPath, routeComponent.routeComponent);
   const pattern = new UrlPattern(path);
-
-  if (pattern.match(toMatch)) {
-    return route;
+  const match = pattern.match(toMatch);
+  if (match) {
+    return [{
+      route: path,
+      params: match,
+      routeComponent
+    }];
   }
 
-  const children = route.children;
+  const children = routeComponent.children;
   if (children) {
     for (const child of children) {
       const result = traverseRoutes(toMatch, child, path);
       if (result) {
-        return [route].concat(result)
+        return [routeComponent].concat(result)
       }
     }
   }

--- a/test.js
+++ b/test.js
@@ -1,48 +1,48 @@
-const UrlPattern = require('url-pattern');
-const pathJoin = require('path').join;
-
-const root = { routeComponent: '/', name:'root' };
-const home = { routeComponent:'home', name:'home' };
-const messages = { routeComponent:'messages', name:'messages' };
-const team = { routeComponent:':team', name:'team' };
-const channel = { routeComponent:':channel', name:'channel' };
-const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
-
-const routes = Object.assign(root, {
-  children: [Object.assign(home, {
-    children: [Object.assign(messages, {
-      children: [Object.assign(team, {
-        children: [Object.assign(channel, {})]
-      })]
-    }), Object.assign(spookyparam, {})]
-  })]
-});
-
-const traverseRoutes = (toMatch, routeComponent, parentPath='') => {
-  const path = pathJoin(parentPath, routeComponent.routeComponent);
-  const pattern = new UrlPattern(path);
-  const match = pattern.match(toMatch);
-  if (match) {
-    return [{
-      route: path,
-      params: match,
-      routeComponent
-    }];
-  }
-
-  const children = routeComponent.children;
-  if (children) {
-    for (const child of children) {
-      const result = traverseRoutes(toMatch, child, path);
-      if (result) {
-        return [routeComponent].concat(result)
-      }
-    }
-  }
-};
-
-const x = traverseRoutes('/home/messages', routes);
-console.log(x);
+// const UrlPattern = require('url-pattern');
+// const pathJoin = require('path').join;
+//
+// const root = { routeComponent: '/', name:'root' };
+// const home = { routeComponent:'home', name:'home' };
+// const messages = { routeComponent:'messages', name:'messages' };
+// const team = { routeComponent:':team', name:'team' };
+// const channel = { routeComponent:':channel', name:'channel' };
+// const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
+//
+// const routes = Object.assign(root, {
+//   children: [Object.assign(home, {
+//     children: [Object.assign(messages, {
+//       children: [Object.assign(team, {
+//         children: [Object.assign(channel, {})]
+//       })]
+//     }), Object.assign(spookyparam, {})]
+//   })]
+// });
+//
+// const traverseRoutes = (toMatch, routeComponent, parentPath='') => {
+//   const path = pathJoin(parentPath, routeComponent.routeComponent);
+//   const pattern = new UrlPattern(path);
+//   const match = pattern.match(toMatch);
+//   if (match) {
+//     return [{
+//       route: path,
+//       params: match,
+//       routeComponent
+//     }];
+//   }
+//
+//   const children = routeComponent.children;
+//   if (children) {
+//     for (const child of children) {
+//       const result = traverseRoutes(toMatch, child, path);
+//       if (result) {
+//         return [routeComponent].concat(result)
+//       }
+//     }
+//   }
+// };
+//
+// const x = traverseRoutes('/home/messages', routes);
+// console.log(x);
 
 //
 //
@@ -73,3 +73,40 @@ console.log(x);
 //   }
 //
 // }
+
+
+// const root = () => ({ routeComponent: '/', name:'root' });
+// const home = () => ({ routeComponent:'home', name:'home' });
+// const messages = () => ({ routeComponent:'messages', name:'messages' });
+// const team = () => ({ routeComponent:':team', name:'team' });
+// const channel = () => ({ routeComponent:':channel', name:'channel' });
+// const spookyparam = () => ({ routeComponent:':spookyparam', name:'3spooky5me' });
+
+const root = { routeComponent: '/', name:'root' };
+const home = { routeComponent:'home', name:'home' };
+const messages = { routeComponent:'messages', name:'messages' };
+const team = { routeComponent:':team', name:'team' };
+const channel = { routeComponent:':channel', name:'channel' };
+const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
+
+function makeRoute(details, children) {
+  return Object.assign({}, details, children ? { children } : {});
+}
+
+const routes = makeRoute(root, [
+  makeRoute(home, [
+    makeRoute(messages, [
+      makeRoute(team, [
+        makeRoute(channel)
+      ])
+    ]),
+    makeRoute(spookyparam)
+  ])
+]);
+
+console.log(routes);
+console.log(routes.children[0]);
+console.log(routes.children[0].children[0]);
+console.log(routes.children[0].children[0].children[0]);
+console.log(routes.children[0].children[0].children[0].children[0]);
+console.log(routes.children[0].children[1]);

--- a/test.js
+++ b/test.js
@@ -1,0 +1,71 @@
+const UrlPattern = require('url-pattern');
+
+const root = { name:'root' };
+const home = { route:'home', name:'home' };
+const messages = { route:'messages', name:'home' };
+const team = { route:':team', name:'team' };
+const channel = { route:':channel', name:'channel' };
+const spookyparam = { route:'spookyparam', name:'3spooky5me' };
+
+const routes = Object.assign(root, {
+  children: [Object.assign(home, {
+    children: [Object.assign(messages, {
+      children: [Object.assign(team, {
+        children: [Object.assign(channel, {})]
+      })]
+    })]
+  }), Object.assign(spookyparam, {})]
+});
+
+// Instead of building a flat route list, recursively match
+const traverseRoutes = (toMatch, route, parentPath='') => {
+  const path = parentPath === '/' ? `/${route.route}` : `${parentPath}/${route.route || ''}`;
+  const pattern = new UrlPattern(path);
+
+  if (pattern.match(toMatch)) {
+    return route;
+  }
+
+  const children = route.children;
+  if (children) {
+    for (const child of children) {
+      const result = traverseRoutes(toMatch, child, path);
+      if (result) {
+        return [route].concat(result)
+      }
+    }
+  }
+};
+
+const x = traverseRoutes('/home/messages', routes);
+console.log(x);
+
+//
+//
+// // build the route list, but do it recursively
+// const routeList = new Map();
+// const traverseRoutes = (route, parentPath='') => {
+//   const path = parentPath === '/' ? `/${route.route}` : `${parentPath}/${route.route || ''}`;
+//   const pattern = new UrlPattern(path);
+//   routeList.set(pattern, route);
+//
+//   const children = route.children;
+//   if (children) {
+//     for (const child of children) {
+//       traverseRoutes(child, path);
+//     }
+//   }
+// };
+//
+// traverseRoutes(routes)
+//
+// for (routeKey of routeList.keys()) {
+//   // console.log(routeKey);
+//   // const pattern = new UrlPattern(routeKey);
+//   const match = routeKey.match('/home/messages');
+//   if (match) {
+//     const route = routeList.get(routeKey);
+//     console.log(route);
+//   }
+//
+// }

--- a/test/create-matcher.spec.js
+++ b/test/create-matcher.spec.js
@@ -116,5 +116,30 @@ describe('createMatcher', () => {
       ]
     });
 
+    expect(matchRoute('/home/global/channel-4')).to.deep.equal({
+      route: '/home/global/:channel',
+      params: {
+        channel: 'channel-4'
+      },
+      result: [
+        {
+          name: 'root',
+          routeComponent: '/'
+        },
+        {
+          name: 'home',
+          routeComponent: 'home'
+        },
+        {
+          name: 'global',
+          routeComponent: 'global'
+        },
+        {
+          name: 'channel',
+          routeComponent: ':channel'
+        }
+      ]
+    });
+
   });
 });

--- a/test/create-matcher.spec.js
+++ b/test/create-matcher.spec.js
@@ -8,49 +8,55 @@ describe('createMatcher', () => {
 
     expect(matchRoute('/home')).to.deep.equal({
       route: '/home',
-      params: {},
-      result: {
-        name: 'home'
-      }
+      result: [
+        {
+          'name': 'root'
+        },
+        {
+          'name': 'home',
+          'route': 'home'
+        }
+      ],
+      params: {}
     });
 
-    expect(matchRoute('/home/messages')).to.deep.equal({
-      route: '/home/messages',
-      params: {},
-      result: {
-        name: 'messages'
-      }
-    });
-
-    expect(matchRoute('/home/messages/a-team')).to.deep.equal({
-      route: '/home/messages/:team',
-      params: {
-        team: 'a-team'
-      },
-      result: {
-        name: 'team'
-      }
-    });
-
-    expect(matchRoute('/home/messages/a-team/the-wat-channel')).to.deep.equal({
-      route: '/home/messages/:team/:channel',
-      params: {
-        team: 'a-team',
-        channel: 'the-wat-channel'
-      },
-      result: {
-        name: 'channel'
-      }
-    });
-
-    expect(matchRoute('/home/doot')).to.deep.equal({
-      route: '/home/:spookyparam',
-      params: {
-        spookyparam: 'doot'
-      },
-      result: {
-        name: '3spooky5me'
-      }
-    });
+    // expect(matchRoute('/home/messages')).to.deep.equal({
+    //   route: '/home/messages',
+    //   params: {},
+    //   result: {
+    //     name: 'messages'
+    //   }
+    // });
+    //
+    // expect(matchRoute('/home/messages/a-team')).to.deep.equal({
+    //   route: '/home/messages/:team',
+    //   params: {
+    //     team: 'a-team'
+    //   },
+    //   result: {
+    //     name: 'team'
+    //   }
+    // });
+    //
+    // expect(matchRoute('/home/messages/a-team/the-wat-channel')).to.deep.equal({
+    //   route: '/home/messages/:team/:channel',
+    //   params: {
+    //     team: 'a-team',
+    //     channel: 'the-wat-channel'
+    //   },
+    //   result: {
+    //     name: 'channel'
+    //   }
+    // });
+    //
+    // expect(matchRoute('/home/doot')).to.deep.equal({
+    //   route: '/home/:spookyparam',
+    //   params: {
+    //     spookyparam: 'doot'
+    //   },
+    //   result: {
+    //     name: '3spooky5me'
+    //   }
+    // });
   });
 });

--- a/test/create-matcher.spec.js
+++ b/test/create-matcher.spec.js
@@ -3,60 +3,118 @@ import { createMatcher } from '../src';
 
 import routes from './fixtures/routes';
 describe('createMatcher', () => {
-  it('matches URLs and returns both their params and their value in the route hash', () => {
+  it('matches URLs and returns the route matched, their params and their value in the route hash', () => {
     const matchRoute = createMatcher(routes);
 
     expect(matchRoute('/home')).to.deep.equal({
       route: '/home',
+      params: {},
       result: [
         {
-          'name': 'root'
+          name: 'root',
+          routeComponent: '/'
         },
         {
-          'name': 'home',
-          'route': 'home'
+          name: 'home',
+          routeComponent: 'home'
         }
-      ],
-      params: {}
+      ]
     });
 
-    // expect(matchRoute('/home/messages')).to.deep.equal({
-    //   route: '/home/messages',
-    //   params: {},
-    //   result: {
-    //     name: 'messages'
-    //   }
-    // });
-    //
-    // expect(matchRoute('/home/messages/a-team')).to.deep.equal({
-    //   route: '/home/messages/:team',
-    //   params: {
-    //     team: 'a-team'
-    //   },
-    //   result: {
-    //     name: 'team'
-    //   }
-    // });
-    //
-    // expect(matchRoute('/home/messages/a-team/the-wat-channel')).to.deep.equal({
-    //   route: '/home/messages/:team/:channel',
-    //   params: {
-    //     team: 'a-team',
-    //     channel: 'the-wat-channel'
-    //   },
-    //   result: {
-    //     name: 'channel'
-    //   }
-    // });
-    //
-    // expect(matchRoute('/home/doot')).to.deep.equal({
-    //   route: '/home/:spookyparam',
-    //   params: {
-    //     spookyparam: 'doot'
-    //   },
-    //   result: {
-    //     name: '3spooky5me'
-    //   }
-    // });
+    expect(matchRoute('/home/messages')).to.deep.equal({
+      route: '/home/messages',
+      params: {},
+      result: [
+        {
+          name: 'root',
+          routeComponent: '/'
+        },
+        {
+          name: 'home',
+          routeComponent: 'home'
+        },
+        {
+          name: 'messages',
+          routeComponent: 'messages'
+        }
+      ]
+    });
+
+    expect(matchRoute('/home/messages/a-team')).to.deep.equal({
+      route: '/home/messages/:team',
+      params: {
+        team: 'a-team'
+      },
+      result: [
+        {
+          name: 'root',
+          routeComponent: '/'
+        },
+        {
+          name: 'home',
+          routeComponent: 'home'
+        },
+        {
+          name: 'messages',
+          routeComponent: 'messages'
+        },
+        {
+          name: 'team',
+          routeComponent: ':team'
+        }
+      ]
+    });
+
+    expect(matchRoute('/home/messages/a-team/the-wat-channel')).to.deep.equal({
+      route: '/home/messages/:team/:channel',
+      params: {
+        team: 'a-team',
+        channel: 'the-wat-channel'
+      },
+      result: [
+        {
+          name: 'root',
+          routeComponent: '/'
+        },
+        {
+          name: 'home',
+          routeComponent: 'home'
+        },
+        {
+          name: 'messages',
+          routeComponent: 'messages'
+        },
+        {
+          name: 'team',
+          routeComponent: ':team'
+        },
+        {
+          name: 'channel',
+          routeComponent: ':channel'
+        }
+      ]
+    });
+
+    expect(matchRoute('/home/doot')).to.deep.equal({
+      route: '/home/:spookyparam',
+      params: {
+        spookyparam: 'doot'
+      },
+      result: [
+        {
+          name: 'root',
+          routeComponent: '/'
+        },
+        {
+          name: 'home',
+          routeComponent: 'home'
+        },
+        {
+          name: '3spooky5me',
+          routeComponent: ':spookyparam'
+        }
+      ]
+    });
+
   });
 });

--- a/test/create-matcher.spec.js
+++ b/test/create-matcher.spec.js
@@ -141,5 +141,22 @@ describe('createMatcher', () => {
       ]
     });
 
+    expect(matchRoute('/a/b/c/dee')).to.deep.equal({
+      route: '/a/b/c/:d',
+      params: {
+        d: 'dee'
+      },
+      result: [
+        {
+          name: 'root',
+          routeComponent: '/'
+        },
+        {
+          name: 'absolute',
+          routeComponent: 'a/b/c/:d'
+        }
+      ]
+    });
+
   });
 });

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -1,3 +1,31 @@
+const root = { routeComponent: '/', name:'root' };
+const home = { routeComponent:'home', name:'home' };
+const messages = { routeComponent:'messages', name:'messages' };
+const team = { routeComponent:':team', name:'team' };
+const channel = { routeComponent:':channel', name:'channel' };
+const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
+const global = { routeComponent:'global', name:'global' };
+
+// Attmempt 7 (Improvement on attempt 6. Seems the simplest)
+function makeRoute(details, ...children) {
+  return Object.assign({}, details, children ? { children } : {});
+}
+
+const routes =
+makeRoute(root,
+  makeRoute(home,
+    makeRoute(messages,
+      makeRoute(team,
+        makeRoute(channel)
+      )
+    ),
+    makeRoute(global,
+      makeRoute(channel)
+    ),
+    makeRoute(spookyparam)
+  )
+);
+
 // Original
 // const routes = {
 //   '/home': {
@@ -16,14 +44,6 @@
 //     name: '3spooky5me'
 //   }
 // };
-
-const root = { routeComponent: '/', name:'root' };
-const home = { routeComponent:'home', name:'home' };
-const messages = { routeComponent:'messages', name:'messages' };
-const team = { routeComponent:':team', name:'team' };
-const channel = { routeComponent:':channel', name:'channel' };
-const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
-
 
 // Attempt 1 (Not bad)
 // const routes =
@@ -151,22 +171,7 @@ const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
 // ]);
 
 
-// Attmempt 7 (Improvement on attempt 6. Seems the simplest)
-function makeRoute(details, ...children) {
-  return Object.assign({}, details, children ? { children } : {});
-}
 
-const routes =
-makeRoute(root,
-  makeRoute(home,
-    makeRoute(messages,
-      makeRoute(team,
-        makeRoute(channel)
-      )
-    ),
-    makeRoute(spookyparam)
-  )
-);
 
 
 // Attempt 8 (Alternate view to 7. On a single line unless there are multiple

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -1,17 +1,36 @@
-export default {
-  '/home': {
-    name: 'home'
-  },
-  '/home/messages': {
-    name: 'messages'
-  },
-  '/home/messages/:team': {
-    name: 'team'
-  },
-  '/home/messages/:team/:channel': {
-    name: 'channel'
-  },
-  '/home/:spookyparam': {
-    name: '3spooky5me'
-  }
-};
+// export default {
+//   '/home': {
+//     name: 'home'
+//   },
+//   '/home/messages': {
+//     name: 'messages'
+//   },
+//   '/home/messages/:team': {
+//     name: 'team'
+//   },
+//   '/home/messages/:team/:channel': {
+//     name: 'channel'
+//   },
+//   '/home/:spookyparam': {
+//     name: '3spooky5me'
+//   }
+// };
+
+const root = { name:'root' };
+const home = { route:'home', name:'home' };
+const messages = { route:'messages', name:'home' };
+const team = { route:':team', name:'team' };
+const channel = { route:':channel', name:'channel' };
+const spookyparam = { route:'spookyparam', name:'3spooky5me' };
+
+const routes = Object.assign(root, {
+  children: [Object.assign(home, {
+    children: [Object.assign(messages, {
+      children: [Object.assign(team, {
+        children: [Object.assign(channel, {})]
+      })]
+    })]
+  }), Object.assign(spookyparam, {})]
+});
+
+export default routes;

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -17,7 +17,6 @@
 //   }
 // };
 
-// Attempt 1 (Possibly the best so far)
 const root = { routeComponent: '/', name:'root' };
 const home = { routeComponent:'home', name:'home' };
 const messages = { routeComponent:'messages', name:'messages' };
@@ -25,107 +24,182 @@ const team = { routeComponent:':team', name:'team' };
 const channel = { routeComponent:':channel', name:'channel' };
 const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
 
-const routes = Object.assign(root, {
-  children: [Object.assign(home, {
-    children: [Object.assign(messages, {
-      children: [Object.assign(team, {
-        children: [Object.assign(channel, {})]
-      })]
-    }), Object.assign(spookyparam, {})]
-  })]
-});
-/*
+
+// Attempt 1 (Not bad)
+// const routes =
+// Object.assign(root, {
+//   children: [Object.assign(home, {
+//     children: [Object.assign(messages, {
+//       children: [Object.assign(team, {
+//         children: [Object.assign(channel, {})]
+//       })]
+//     }), Object.assign(spookyparam, {})]
+//   })]
+// });
+
 // Attempt 2 (Awful)
-const routes = Object.assign(
-  root, {
-    children: [
-      Object.assign(
-        home, {
-          children: [
-            Object.assign(
-              messages, {
-                children: [
-                  Object.assign(
-                    team, {
-                      children: [
-                        Object.assign(
-                          channel,
-                          {}
-                        )
-                      ]
-                    }
-                  )
-                ]
-              }
-            ),
-            Object.assign(
-              spookyparam,
-              {}
-            )
-          ]
-        }
+// const routes =
+// Object.assign(
+//   root, {
+//     children: [
+//       Object.assign(
+//         home, {
+//           children: [
+//             Object.assign(
+//               messages, {
+//                 children: [
+//                   Object.assign(
+//                     team, {
+//                       children: [
+//                         Object.assign(
+//                           channel,
+//                           {}
+//                         )
+//                       ]
+//                     }
+//                   )
+//                 ]
+//               }
+//             ),
+//             Object.assign(
+//               spookyparam,
+//               {}
+//             )
+//           ]
+//         }
+//       )
+//     ]
+//   }
+// );
+
+// Attempt 3 (Also pretty awful)
+// const routes =
+// {
+//   name:'root',
+//   children: [
+//     {
+//       name: 'home',
+//       route: 'home',
+//       children: [
+//         {
+//           route: 'messages',
+//           name: 'messages',
+//           children: [
+//             {
+//               route:':team',
+//               name:'team',
+//               children: [
+//                 {
+//                   route:':channel',
+//                   name:'channel'
+//                 }
+//               ]
+//             }
+//           ]
+//         },
+//         {
+//           route:':spookyparam',
+//           name:'3spooky5me'
+//         }
+//       ]
+//     }
+//   ]
+// };
+
+// Attempt 4 (Another fairly awful one)
+// const routes =
+// { name:'root', children: [
+//   { name: 'home', route: 'home', children: [
+//     { route: 'messages', name: 'messages', children: [
+//       { route:':team', name:'team', children: [
+//         { route:':channel', name:'channel' }
+//       ]}
+//     ]}, { route:':spookyparam', name:'3spooky5me' }
+//   ]}
+// ]};
+
+// Attempt 5 (Reverse order, kinda tidy, but potentially confusing)
+// const channel = { route:':channel', name:'channel' };
+//
+// const team = { route:':team', name:'team', children: [channel] };
+//
+// const messages = { route:'messages', name:'messages', children: [team] };
+// const spookyparam = { route:':spookyparam', name:'3spooky5me' };
+//
+// const home = { route:'home', name:'home', children: [messages, spookyparam] };
+//
+// const root = { name:'root', children: [home] };
+//
+// const routes = root;
+
+
+// Attempt 6 (Improvement on attempt 1)
+// function makeRoute(details, children) {
+//   return Object.assign({}, details, children ? { children } : {});
+// }
+//
+// const routes =
+// makeRoute(root, [
+//   makeRoute(home, [
+//     makeRoute(messages, [
+//       makeRoute(team, [
+//         makeRoute(channel)
+//       ])
+//     ]),
+//     makeRoute(spookyparam)
+//   ])
+// ]);
+
+
+// Attmempt 7 (Improvement on attempt 6. Seems the simplest)
+function makeRoute(details, ...children) {
+  return Object.assign({}, details, children ? { children } : {});
+}
+
+const routes =
+makeRoute(root,
+  makeRoute(home,
+    makeRoute(messages,
+      makeRoute(team,
+        makeRoute(channel)
       )
-    ]
-  }
+    ),
+    makeRoute(spookyparam)
+  )
 );
 
-// Attempt 3 (Not awful, but not good)
-const routes = {
-  name:'root',
-  children: [
-    {
-      name: 'home',
-      route: 'home',
-      children: [
-        {
-          route: 'messages',
-          name: 'messages',
-          children: [
-            {
-              route:':team',
-              name:'team',
-              children: [
-                {
-                  route:':channel',
-                  name:'channel'
-                }
-              ]
-            }
-          ]
-        },
-        {
-          route:':spookyparam',
-          name:'3spooky5me'
-        }
-      ]
-    }
-  ]
-};
 
-// Attempt 4 (Awful)
-const routes = { name:'root', children: [
-  { name: 'home', route: 'home', children: [
-    { route: 'messages', name: 'messages', children: [
-      { route:':team', name:'team', children: [
-        { route:':channel', name:'channel' }
-      ]}
-    ]}, { route:':spookyparam', name:'3spooky5me' }
-  ]}
-]};
+// Attempt 8 (Alternate view to 7. On a single line unless there are multiple
+// children)
+// function makeRoute(details, ...children) {
+//   return Object.assign({}, details, children ? { children } : {});
+// }
+//
+// const routes =
+// makeRoute(root,
+//   makeRoute(home,
+//     makeRoute(messages, makeRoute(team, makeRoute(channel))),
+//     makeRoute(spookyparam)
+//   )
+// );
 
-// Attempt 5 (Reverse order potentially confusing)
-const channel = { route:':channel', name:'channel' };
 
-const team = { route:':team', name:'team', children: [channel] };
+// Attempt 9 (Inline version of 7. Also pretty good)
+// function makeRoute(details, ...children) {
+//   return Object.assign({}, details, children ? { children } : {});
+// }
+//
+// const routes =
+// makeRoute({ routeComponent: '/', name:'root' },
+//   makeRoute({ routeComponent:'home', name:'home' },
+//     makeRoute({ routeComponent:'messages', name:'messages' },
+//       makeRoute({ routeComponent:':team', name:'team' },
+//         makeRoute({ routeComponent:':channel', name:'channel' })
+//       )
+//     ),
+//     makeRoute({ routeComponent:':spookyparam', name:'3spooky5me' })
+//   )
+// );
 
-const messages = { route:'messages', name:'messages', children: [team] };
-const spookyparam = { route:':spookyparam', name:'3spooky5me' };
-
-const home = { route:'home', name:'home', children: [messages, spookyparam] };
-
-const root = { name:'root', children: [home] };
-
-const routes = root;
-*/
 
 export default routes;

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -1,4 +1,5 @@
-// export default {
+// Original
+// const routes = {
 //   '/home': {
 //     name: 'home'
 //   },
@@ -16,12 +17,13 @@
 //   }
 // };
 
-const root = { name:'root' };
-const home = { route:'home', name:'home' };
-const messages = { route:'messages', name:'home' };
-const team = { route:':team', name:'team' };
-const channel = { route:':channel', name:'channel' };
-const spookyparam = { route:'spookyparam', name:'3spooky5me' };
+// Attempt 1 (Possibly the best so far)
+const root = { routeComponent: '/', name:'root' };
+const home = { routeComponent:'home', name:'home' };
+const messages = { routeComponent:'messages', name:'messages' };
+const team = { routeComponent:':team', name:'team' };
+const channel = { routeComponent:':channel', name:'channel' };
+const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
 
 const routes = Object.assign(root, {
   children: [Object.assign(home, {
@@ -29,8 +31,101 @@ const routes = Object.assign(root, {
       children: [Object.assign(team, {
         children: [Object.assign(channel, {})]
       })]
-    })]
-  }), Object.assign(spookyparam, {})]
+    }), Object.assign(spookyparam, {})]
+  })]
 });
+/*
+// Attempt 2 (Awful)
+const routes = Object.assign(
+  root, {
+    children: [
+      Object.assign(
+        home, {
+          children: [
+            Object.assign(
+              messages, {
+                children: [
+                  Object.assign(
+                    team, {
+                      children: [
+                        Object.assign(
+                          channel,
+                          {}
+                        )
+                      ]
+                    }
+                  )
+                ]
+              }
+            ),
+            Object.assign(
+              spookyparam,
+              {}
+            )
+          ]
+        }
+      )
+    ]
+  }
+);
+
+// Attempt 3 (Not awful, but not good)
+const routes = {
+  name:'root',
+  children: [
+    {
+      name: 'home',
+      route: 'home',
+      children: [
+        {
+          route: 'messages',
+          name: 'messages',
+          children: [
+            {
+              route:':team',
+              name:'team',
+              children: [
+                {
+                  route:':channel',
+                  name:'channel'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          route:':spookyparam',
+          name:'3spooky5me'
+        }
+      ]
+    }
+  ]
+};
+
+// Attempt 4 (Awful)
+const routes = { name:'root', children: [
+  { name: 'home', route: 'home', children: [
+    { route: 'messages', name: 'messages', children: [
+      { route:':team', name:'team', children: [
+        { route:':channel', name:'channel' }
+      ]}
+    ]}, { route:':spookyparam', name:'3spooky5me' }
+  ]}
+]};
+
+// Attempt 5 (Reverse order potentially confusing)
+const channel = { route:':channel', name:'channel' };
+
+const team = { route:':team', name:'team', children: [channel] };
+
+const messages = { route:'messages', name:'messages', children: [team] };
+const spookyparam = { route:':spookyparam', name:'3spooky5me' };
+
+const home = { route:'home', name:'home', children: [messages, spookyparam] };
+
+const root = { name:'root', children: [home] };
+
+const routes = root;
+*/
 
 export default routes;

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -1,3 +1,5 @@
+import {makeRoute } from '../../src';
+
 const root = { routeComponent: '/', name:'root' };
 const home = { routeComponent:'home', name:'home' };
 const messages = { routeComponent:'messages', name:'messages' };
@@ -5,11 +7,7 @@ const team = { routeComponent:':team', name:'team' };
 const channel = { routeComponent:':channel', name:'channel' };
 const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };
 const global = { routeComponent:'global', name:'global' };
-
-// Attmempt 7 (Improvement on attempt 6. Seems the simplest)
-function makeRoute(details, ...children) {
-  return Object.assign({}, details, children ? { children } : {});
-}
+const absolute = { routeComponent:'a/b/c/:d', name:'absolute' }
 
 const routes =
 makeRoute(root,
@@ -23,7 +21,8 @@ makeRoute(root,
       makeRoute(channel)
     ),
     makeRoute(spookyparam)
-  )
+  ),
+  makeRoute(absolute)
 );
 
 // Original

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -108,4 +108,45 @@ describe('Fragment', () => {
     );
     expect(wrapper.find('p')).to.have.lengthOf(0);
   });
+
+  it('renders if the current URL matches a given route component', () => {
+    const wrapper = mount(
+      <Fragment inRoute=':team'>
+        <p>As you know, the key to victory is the element of surprise. Surprise!</p>
+      </Fragment>,
+      fakeContext({
+        pathname: '/home/messages/a-team'
+      })
+    );
+    expect(wrapper.find('p').node.textContent).to.equal(
+      'As you know, the key to victory is the element of surprise. Surprise!'
+    );
+  });
+
+  it('renders nothing if the current URL does not match a given route component', () => {
+    const wrapper = mount(
+      <Fragment inRoute='messages'>
+        <p>Nothing to see here!</p>
+      </Fragment>,
+      fakeContext({
+        pathname: '/home'
+      })
+    );
+    expect(wrapper.find('p')).to.have.lengthOf(0);
+  });
+
+  it('renders if the current URL matches a given parent route component', () => {
+    const wrapper = mount(
+      <Fragment inRoute='home'>
+        <p>You win again, gravity!</p>
+      </Fragment>,
+      fakeContext({
+        pathname: '/home/messages/a-team'
+      })
+    );
+    expect(wrapper.find('p').node.textContent).to.equal(
+      'You win again, gravity!'
+    );
+  });
+
 });

--- a/test/store-enhancer.spec.js
+++ b/test/store-enhancer.spec.js
@@ -119,7 +119,16 @@ describe('Router store enhancer', () => {
         query: { yo: 'yo' },
         route: '/home',
         params: {},
-        result: { name: 'home' }
+        result: [
+          {
+            name: 'root',
+            routeComponent: '/'
+          },
+          {
+            name: 'home',
+            routeComponent: 'home'
+          }
+        ]
       });
   });
 
@@ -140,7 +149,16 @@ describe('Router store enhancer', () => {
         query: { yo: 'yo' },
         route: '/home',
         params: {},
-        result: { name: 'home' }
+        result: [
+          {
+            name: 'root',
+            routeComponent: '/'
+          },
+          {
+            name: 'home',
+            routeComponent: 'home'
+          }
+        ]
       });
   });
 


### PR DESCRIPTION
I am opening this PR to add nested route support within the route configuration and matcher. It is not complete and certainly requires some discussion as currently it's a breaking change in as far as what the route configuration object must look like. There would definitely be ways to make it compatible though. It also differs in what is delivered to the `Fragment` as the `result`. Instead of the single matching routes details, it's an array of all the details from the route components that constitute the current route.

I added some test cases to demonstrate.

Basically it works like this though:

- Define routes from nested route components. I am hoping to improve on the readability of this:

```js
const root = { routeComponent: '/', name:'root' };
const home = { routeComponent:'home', name:'home' };
const messages = { routeComponent:'messages', name:'messages' };
const team = { routeComponent:':team', name:'team' };
const channel = { routeComponent:':channel', name:'channel' };
const spookyparam = { routeComponent:':spookyparam', name:'3spooky5me' };

const routes = Object.assign(root, {
  children: [Object.assign(home, {
    children: [Object.assign(messages, {
      children: [Object.assign(team, {
        children: [Object.assign(channel, {})]
      })]
    }), Object.assign(spookyparam, {})]
  })]
});
```

- When matching a route. This route component tree is traversed as a depth first search. There are other ways to do this, but this was the simplest to implement as a first pass. When a route is matched, it returns the standard structure of:

```
{
  route: The route which has actually been matched,
  params: Any parameters (or empty object) that have been matched,
  result: The tree components involved in this route
}
```
but where the result is now an array of the route components in order, so metadata supplied in any of them could be used in the `Fragment`.

- The `Fragment` now has a new property `inRoute` that matches any of the route components in the `result` (potentially this should not be in `result`). This can be ambiguous (if two route components had the same pattern), so it could be switched to use the route component names instead.

There's still work to be done, but it doesn't seem too difficult and I really think that nested routes are an essential feature.