### PR TITLE
Return unwrapped children from Fragment.

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -2,7 +2,7 @@
 import type { Location } from 'history';
 import type { RouterContext } from './provider';
 
-import React, { PropTypes } from 'react';
+import { PropTypes } from 'react';
 
 type Props = {
   forRoute: string,
@@ -47,7 +47,7 @@ const Fragment = (
     return null;
   }
 
-  return <div>{children}</div>;
+  return children;
 };
 
 Fragment.contextTypes = {


### PR DESCRIPTION
wrapping the `children` object in a `<div>` in `Fragment` can have side effects with the CSS on the page. It doesn't seem like the `<div>` was doing anything, so this removes it.