### PR TITLE
Allow unserializable route properties (e.g. components) in routes

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -1,7 +1,12 @@
 // @flow
 import type { Store } from 'redux';
 
-import React, { Component, PropTypes } from 'react';
+import React, {
+  Component,
+  PropTypes,
+  cloneElement
+} from 'react';
+
 import { connect } from 'react-redux';
 
 export type RouterContext = { store: Store };
@@ -28,7 +33,20 @@ class RouterProviderImpl extends Component {
   }
 
   render() {
-    return this.props.children;
+    const { store } = this.router;
+    const routerState = store.getState().router;
+
+    // Ensure that the router props from connect()
+    // actually get to the child component(s)
+    return cloneElement(this.props.children, {
+      router: {
+        ...routerState,
+
+        // This is a hack to allow routes to define
+        // unserializable things like components
+        result: store.routes[routerState.route]
+      }
+    });
   }
 }
 

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -190,6 +190,16 @@ export default ({
       }
     };
 
-    return {...store, dispatch, history, matchRoute};
+    return {
+      ...store,
+      dispatch,
+
+      // We attach routes here to allow <RouterProvider>
+      // to access unserializable properties of route results.
+      routes,
+
+      history,
+      matchRoute
+    };
   };
 };

--- a/test/provider.spec.js
+++ b/test/provider.spec.js
@@ -6,6 +6,7 @@ import React, { Component, PropTypes } from 'react';
 import provideRouter, { RouterProvider } from '../src/provider';
 
 import { fakeStore } from './util';
+import routesFixture from './fixtures/routes';
 
 describe('Router provider', () => {
   describe('provideRouter HoC', () => {
@@ -52,6 +53,65 @@ describe('Router provider', () => {
 
       const div = wrapper.find('div');
       expect(div.node.textContent).to.equal('/home/messages/b-team');
+    });
+
+    it('adds router location props to its child component', () => {
+      class MagicalMysteryComponent extends Component {
+        render() {
+          return <div>{this.props.router.pathname}</div>;
+        }
+      }
+
+      MagicalMysteryComponent.propTypes = {
+        router: PropTypes.object
+      };
+
+      const wrapper = mount(
+        <RouterProvider store={fakeStore()}>
+          <MagicalMysteryComponent />
+        </RouterProvider>
+      );
+
+      const div = wrapper.find('div');
+      expect(div.node.textContent).to.equal('/home/messages/b-team');
+    });
+
+    it('passes down unserializable route results', () => {
+      class NoopComponent extends Component {
+        render() {
+          return <p>lol</p>;
+        }
+      }
+
+      class MagicalMysteryComponent extends Component {
+        render() {
+          return <div>{this.props.router.pathname}</div>;
+        }
+      }
+
+      MagicalMysteryComponent.propTypes = {
+        router: PropTypes.object
+      };
+
+      const routesWithComponent = {
+        ...routesFixture,
+        '/home/messages/:team': {
+          ...routesFixture['/home/messages/:team'],
+          component: NoopComponent
+        }
+      };
+
+      const wrapper = mount(
+        <RouterProvider store={fakeStore({
+          routes: routesWithComponent
+        })}>
+          <MagicalMysteryComponent />
+        </RouterProvider>
+      );
+
+      const childProps = wrapper.find(MagicalMysteryComponent).props();
+      expect(childProps).to.have.deep.property('router.result.component')
+        .that.equals(NoopComponent);
     });
   });
 });

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -3,7 +3,7 @@ import createMemoryHistory from 'history/lib/createMemoryHistory';
 
 import createMatcher from '../../src/create-matcher';
 
-import routes from '../fixtures/routes';
+import defaultRoutes from '../fixtures/routes';
 
 export const captureErrors = (done, assertions) => {
   try {
@@ -18,6 +18,8 @@ export const fakeStore = ({
   assertion,
   pathname = '/home/messages/b-team',
   query = { test: 'ing' },
+  route = '/home/messages/:team',
+  routes = defaultRoutes,
   fakeNewLocation
 } = {}) => {
   const history = createMemoryHistory();
@@ -37,7 +39,8 @@ export const fakeStore = ({
           pathname,
           query,
           search: '?test=ing',
-          action: 'POP'
+          action: 'POP',
+          route
         }
       };
     },
@@ -46,8 +49,9 @@ export const fakeStore = ({
       assertion && assertion(action);
     },
 
-    matchRoute: createMatcher(routes),
-    history
+    routes,
+    history,
+    matchRoute: createMatcher(routes)
   };
 };
 


### PR DESCRIPTION
There's a use case for higher-level routing that attaches React component classes to the route results. Since components aren't serializable, Redux ignores any keys in the route object containing components, functions, or any other unserializable things.

This is a workaround, with the caveat that unserializable properties will only appear in `props.router.result` in the first child component of `<RouterProvider>`. I'd like a better solution before adding unserializable properties to `<RouterProvider>`'s `context`.

@kriuz can you pull this branch and `npm link` to make sure this works for you?

/cc @baer 