### PR TITLE
Fix flow choking on broken node module in CI

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 dist/
 lib/
 .*/node_modules/fbjs/.*
+.*/node_modules/systemjs-builder/.*
 .*/__tests__/.*
 .*/__mocks__/.*
 .*/node_modules/flow-typed/src/.*


### PR DESCRIPTION
(updated the `.flowconfig` to ignore it)