### PR TITLE
Fix undefined previous state

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,10 +10,17 @@ export default (state: ?Location | Object = {}, action: Action) => {
       return state;
     }
 
-    return {
-      ...action.payload,
-      previous: state && state.current
-    };
+    // Extract the previous state, but dump the
+    // previous state's previous state so that the
+    // state tree doesn't keep growing indefinitely
+    if (state) {
+      // eslint-disable-next-line no-unused-vars
+      const { previous, ...oldState } = state;
+      return {
+        ...action.payload,
+        previous: oldState
+      };
+    }
   }
   return state;
 };

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -28,7 +28,7 @@ describe('Router reducer', () => {
       state: {
         bork: 'bork'
       },
-      previous: undefined
+      previous: {}
     });
   });
 


### PR DESCRIPTION
This got lost when we stopped using the `current` key in the router state.