### PR TITLE
Fix noop on changed query, same path

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "history": "^3.0.0",
     "lodash.assign": "^4.2.0",
+    "lodash.isequal": "^4.4.0",
     "url-pattern": "^1.0.1"
   },
   "devDependencies": {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,7 +2,7 @@
 import type { Action } from 'redux';
 import type { Location } from 'history';
 import { LOCATION_CHANGED } from './action-types';
-import isEqual from 'lodash.isEqual';
+import isEqual from 'lodash.isequal';
 
 export default (state: ?Location | Object = {}, action: Action) => {
   if (action.type === LOCATION_CHANGED) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,11 +2,16 @@
 import type { Action } from 'redux';
 import type { Location } from 'history';
 import { LOCATION_CHANGED } from './action-types';
+import isEqual from 'lodash.isEqual';
 
 export default (state: ?Location | Object = {}, action: Action) => {
   if (action.type === LOCATION_CHANGED) {
     // No-op the initial route action
-    if (state && state.pathname === action.payload.pathname) {
+    if (
+      state &&
+      state.pathname === action.payload.pathname &&
+      isEqual(state.query, action.payload.isEqual)
+    ) {
       return state;
     }
 


### PR DESCRIPTION
Right now, if a `query` parameter is changed but the `pathname` remains the same, the reducer does not persist the state.

I would add tests, but I'm having trouble installing the dev deps (some OpenSSL error, may be due to the recent MacOS Sierra update).

EDIT:

To verify:
1. go to a route
2. click a `<Link />` to the same page with a different query parameter
