### PR TITLE
fix #90 - state unchanged after query change

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "history": "^3.0.0",
     "lodash.assign": "^4.2.0",
-    "lodash.isequal": "^4.4.0",
     "url-pattern": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "history": "^3.0.0",
     "lodash.assign": "^4.2.0",
+    "lodash.isequal": "^4.4.0",
     "url-pattern": "^1.0.1"
   },
   "devDependencies": {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,7 +2,6 @@
 import type { Action } from 'redux';
 import type { Location } from 'history';
 import { LOCATION_CHANGED } from './action-types';
-import isEqual from 'lodash.isequal';
 
 export default (state: ?Location | Object = {}, action: Action) => {
   if (action.type === LOCATION_CHANGED) {
@@ -10,7 +9,7 @@ export default (state: ?Location | Object = {}, action: Action) => {
     if (
       state &&
       state.pathname === action.payload.pathname &&
-      isEqual(state.query, action.payload.query)
+      state.search === action.payload.search
     ) {
       return state;
     }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,11 +2,16 @@
 import type { Action } from 'redux';
 import type { Location } from 'history';
 import { LOCATION_CHANGED } from './action-types';
+import isEqual from 'lodash.isequal';
 
 export default (state: ?Location | Object = {}, action: Action) => {
   if (action.type === LOCATION_CHANGED) {
     // No-op the initial route action
-    if (state && state.pathname === action.payload.pathname) {
+    if (
+      state &&
+      state.pathname === action.payload.pathname &&
+      isEqual(state.query, action.payload.query)
+    ) {
       return state;
     }
 


### PR DESCRIPTION
Right now, if a query parameter is changed but the pathname remains the same, the reducer does not persist the state.

I would add tests, but I've been unable to install some of the dev dependencies required for testing.