### PR TITLE
Parse query in href

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -115,7 +115,6 @@ const Link = (
   const location = router.store.history
     .createLocation(locationDescriptor);
 
-
   return (
     <a
       href={normalizeHref(location)}

--- a/src/link.js
+++ b/src/link.js
@@ -18,8 +18,8 @@ type Props = {
 
 const LEFT_MOUSE_BUTTON = 0;
 
-const normalizeHref = location =>
-  `${location.basename || ''}${location.pathname}`;
+const normalizeHref = ({ basename, pathname, search }) =>
+  `${basename || ''}${pathname}${search || ''}`;
 
 const normalizeLocation = href => {
   if (typeof href === 'string') {
@@ -114,6 +114,7 @@ const Link = (
 
   const location = router.store.history
     .createLocation(locationDescriptor);
+
 
   return (
     <a

--- a/test/link.spec.js
+++ b/test/link.spec.js
@@ -202,6 +202,39 @@ describe('Router link component', () => {
           });
       });
     });
+    describe('Rendering', () => {
+      it('renders an <a/> with the correct href attribute', () => {
+        const hrefs = [
+          '/path',
+          '/path?key=value',
+          'path/with/nested/routes'
+        ];
+        hrefs.forEach(href => {
+          const wrapper = shallow(<Link href={href} />, fakeContext());
+          expect(wrapper.find('a').prop('href')).to.equal(href);
+        });
+      });
+
+      it('parses and renders location objects as hrefs', () => {
+        const expected = [
+          '/path',
+          '/path?key=value',
+          'path/with/nested/routes'
+        ];
+        const locations = [
+          { pathname: '/path' },
+          { pathname: '/path', query: { key: 'value' } },
+          { pathname: 'path/with/nested/routes' }
+        ];
+        locations.forEach((location, index) => {
+          const wrapper = shallow(
+            <Link href={location} />,
+            fakeContext()
+          );
+          expect(wrapper.find('a').prop('href')).to.equal(expected[index]);
+        });
+      });
+    });
   });
 
   // We have to use mount instead of shallow here since

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import createMemoryHistory from 'history/lib/createMemoryHistory';
+import useQueries from 'history/lib/useQueries';
 
 import createMatcher from '../../src/create-matcher';
 
@@ -22,7 +23,7 @@ export const fakeStore = ({
   routes = defaultRoutes,
   fakeNewLocation
 } = {}) => {
-  const history = createMemoryHistory();
+  const history = useQueries(createMemoryHistory)();
   if (fakeNewLocation) {
     sinon.stub(history, 'createLocation')
       .returns(fakeNewLocation);


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/redux-little-router/issues/98

* `normalizeHref` now includes `location.search`  if it exists
* Adds tests that verify `href` is being rendered correctly
* Applies the `useQueries` enhancer to the `history`used in `fakeStore`. This is required to test that queries are being parsed correctly, and ideally the history instance in the testing environment should match the production instance as closely as possible.