### PR TITLE
Middleware returns, flowing downstream promises up to root dispatch

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,3 +1,5 @@
+/* eslint-disable consistent-return */
+
 import {
   PUSH, REPLACE, GO,
   GO_BACK, GO_FORWARD
@@ -7,6 +9,8 @@ export default ({ history }) => () => next => action => {
   switch (action.type) {
   case PUSH:
     history.push(action.payload);
+    // No return, no next() here
+    // We stop all history events from progressing further through the dispatch chain...
     break;
   case REPLACE:
     history.replace(action.payload);
@@ -21,6 +25,7 @@ export default ({ history }) => () => next => action => {
     history.goForward();
     break;
   default:
-    next(action);
+    // ...but we want to leave all events we don't care about undisturbed
+    return next(action);
   }
 };

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -89,9 +89,7 @@ describe('AbsoluteFragment', () => {
 
   it('renders if the current location matches a predicate function', () => {
     const wrapper = mount(
-      <AbsoluteFragment withConditions={
-        location => location.query.ayy === 'lmao'
-      }>
+      <AbsoluteFragment withConditions={location => location.query.ayy === 'lmao'}>
         <p>In the game of chess, you can never let your adversary see your pieces.</p>
       </AbsoluteFragment>,
       fakeContext({
@@ -107,9 +105,7 @@ describe('AbsoluteFragment', () => {
 
   it('does not render if the current location does not match a predicate function', () => {
     const wrapper = mount(
-      <AbsoluteFragment withConditions={
-        location => location.query.ayy === 'jk'
-      }>
+      <AbsoluteFragment withConditions={location => location.query.ayy === 'jk'}>
         <p>In the game of chess, you can never let your adversary see your pieces.</p>
       </AbsoluteFragment>,
       fakeContext({

--- a/test/provider.spec.js
+++ b/test/provider.spec.js
@@ -102,9 +102,7 @@ describe('Router provider', () => {
       };
 
       const wrapper = mount(
-        <RouterProvider store={fakeStore({
-          routes: routesWithComponent
-        })}>
+        <RouterProvider store={fakeStore({ routes: routesWithComponent })}>
           <MagicalMysteryComponent />
         </RouterProvider>
       );


### PR DESCRIPTION
When combining `redux-loop` with other middleware, [I've found it useful to put it after my middleware](https://blog.scottnonnenberg.com/better-async-redux-i18n-and-node-js-versions/#integrating-it-into-your-app). That way, all new actions generated by middleware will be processed by `redux-loop`. Then, `redux-loop` returns a promise from its overridden `dispatch()` which lets me know when the current action and any child `Effect` is done.

And so, any middleware which doesn't return the result of its `next()` call breaks that chain back up to the root `dispatch()` call.

This PR introduces that needed `return` statement in the router middleware.