### PR TITLE
Pass parent state to the enhanced router

### DIFF
--- a/src/reducer-enhancer.js
+++ b/src/reducer-enhancer.js
@@ -4,26 +4,9 @@ import routerReducer from './reducer';
 
 export default (vanillaReducer: Reducer) =>
   (state: State, action: Action) => {
-    const vanillaState = { ...state };
-    delete vanillaState.router;
-
-    const newState = vanillaReducer(vanillaState, action);
-
-    // Support redux-loop
-    if (Array.isArray(newState)) {
-      const nextState = newState[0]; // eslint-disable-line no-magic-numbers
-      const nextEffects = newState[1]; // eslint-disable-line no-magic-numbers
-      return [
-        {
-          ...nextState,
-          router: routerReducer(state && state.router, action)
-        },
-        nextEffects
-      ];
-    }
-
-    return {
-      ...newState,
+    const stateWithRouter = {
+      ...state,
       router: routerReducer(state && state.router, action)
     };
+    return vanillaReducer(stateWithRouter, action);
   };

--- a/test/store-enhancer.spec.js
+++ b/test/store-enhancer.spec.js
@@ -169,6 +169,15 @@ describe('Router store enhancer', () => {
       });
   });
 
+  it('passes router state to the enhanced/vanilla reducer', () => {
+    const reducerSpy = sandbox.spy(state => {
+      expect(state).to.have.property('router');
+      return state;
+    });
+    fakeStore({ reducer: reducerSpy });
+    expect(reducerSpy).to.be.calledOnce;
+  });
+
   it('supports Redux Loop', done => {
     const { store } = fakeStore({ isLoop: true });
 
@@ -202,11 +211,14 @@ describe('Router store enhancer', () => {
   });
 
   it('calls the reducer once for each action', () => {
-    const reducerSpy = sandbox.spy();
+    const reducerSpy = sandbox.spy(state => {
+      expect(state).to.have.property('router');
+      return state;
+    });
     const { store } = fakeStore({ reducer: reducerSpy });
     store.dispatch({ type: 'CUSTOM_ACTION' });
     expect(reducerSpy).to.be.calledTwice;
-    expect(reducerSpy.firstCall).to.have.been.calledWith({}, { type: '@@redux/INIT' });
-    expect(reducerSpy.secondCall).to.have.been.calledWith({}, { type: 'CUSTOM_ACTION' });
+    expect(reducerSpy.firstCall.args[1]).to.deep.equal({ type: '@@redux/INIT' });
+    expect(reducerSpy.secondCall.args[1]).to.deep.equal({ type: 'CUSTOM_ACTION' });
   });
 });


### PR DESCRIPTION
This allows child reducers to depend on router state. Check out the diff on `router-enhancer.js`!

/cc @baer @divmain 