### PR TITLE
Fix normal combineReducers usage by making router state passing optional

### DIFF
--- a/src/browser-router.js
+++ b/src/browser-router.js
@@ -9,7 +9,8 @@ import routerMiddleware from './middleware';
 type BrowserRouterArgs = {
   routes: Object,
   basename: string,
-  getLocation: () => Location
+  getLocation: () => Location,
+  passRouterStateToReducer?: bool
 };
 
 /* istanbul ignore next: unstubbable! */
@@ -18,7 +19,8 @@ const realLocation = () => window.location;
 export default ({
   routes,
   basename,
-  getLocation = realLocation
+  getLocation = realLocation,
+  passRouterStateToReducer = false
 }: BrowserRouterArgs) => {
   const history = useBasename(useQueries(createBrowserHistory))({
     basename
@@ -29,7 +31,12 @@ export default ({
     .createLocation({ pathname, search });
 
   return {
-    routerEnhancer: installRouter({ routes, history, location }),
+    routerEnhancer: installRouter({
+      routes,
+      history,
+      location,
+      passRouterStateToReducer
+    }),
     routerMiddleware: routerMiddleware({ history })
   };
 };

--- a/src/express-router.js
+++ b/src/express-router.js
@@ -13,10 +13,15 @@ type ServerRouterArgs = {
     baseUrl: string,
     url: string,
     query: {[key: string]: string}
-  }
+  },
+  passRouterStateToReducer?: bool
 };
 
-export default ({ routes, request }: ServerRouterArgs) => {
+export default ({
+  routes,
+  request,
+  passRouterStateToReducer = false
+}: ServerRouterArgs) => {
   const history = useBasename(useQueries(createMemoryHistory))({
     basename: request.baseUrl
   });
@@ -27,7 +32,12 @@ export default ({ routes, request }: ServerRouterArgs) => {
   });
 
   return {
-    routerEnhancer: installRouter({ routes, history, location }),
+    routerEnhancer: installRouter({
+      routes,
+      history,
+      location,
+      passRouterStateToReducer
+    }),
     routerMiddleware: routerMiddleware({ history })
   };
 };

--- a/src/reducer-enhancer.js
+++ b/src/reducer-enhancer.js
@@ -6,10 +6,13 @@ export default
   (passRouterStateToReducer: bool) =>
   (vanillaReducer: Reducer) =>
   (state: State, action: Action) => {
-    // We have to do this destructuring dance to remove the
-    // previous router state from the state we pass to the
-    // vanilla reducer. Otherwise, `combineReducers` complains
-    // about extraneous keys and ditches the router state.
+    // Here, we use destructuring in place of `_.omit`
+    // to remove the `router` key from the vanilla state.
+    // We remove this key because passing state to
+    // `combineReducers` with keys it doesn't recognize
+    // triggers a warning. Worse, `combineReducers` ignores
+    // the extraneous key, and therefore stops router state
+    // from propagating to the final reduced state.
     //
     // eslint-disable-next-line no-unused-vars
     const { router, ...vanillaState } = state;

--- a/src/reducer-enhancer.js
+++ b/src/reducer-enhancer.js
@@ -2,11 +2,46 @@
 import type { Reducer, State, Action } from 'redux';
 import routerReducer from './reducer';
 
-export default (vanillaReducer: Reducer) =>
+export default
+  (passRouterStateToReducer: bool) =>
+  (vanillaReducer: Reducer) =>
   (state: State, action: Action) => {
-    const stateWithRouter = {
-      ...state,
-      router: routerReducer(state && state.router, action)
+    // We have to do this destructuring dance to remove the
+    // previous router state from the state we pass to the
+    // vanilla reducer. Otherwise, `combineReducers` complains
+    // about extraneous keys and ditches the router state.
+    //
+    // eslint-disable-next-line no-unused-vars
+    const { router, ...vanillaState } = state;
+    const routerState = routerReducer(state && state.router, action);
+
+    // If we're passing the router state to the vanilla reducer,
+    // we don't need any special support for redux-loop
+    if (passRouterStateToReducer) {
+      const stateWithRouter = {
+        ...vanillaState,
+        router: routerState
+      };
+      return vanillaReducer(stateWithRouter, action);
+    }
+
+    const newState = vanillaReducer(vanillaState, action);
+
+    // Support redux-loop
+    if (Array.isArray(newState)) {
+      const nextState = newState[0];
+      const nextEffects = newState[1];
+      return [
+        {
+          ...nextState,
+          router: routerState
+        },
+        nextEffects
+      ];
+    }
+
+    return {
+      ...newState,
+      router: routerState
     };
-    return vanillaReducer(stateWithRouter, action);
   };

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -19,14 +19,16 @@ type StoreEnhancerArgs = {
   routes: Object,
   history: History,
   location: Location,
-  createMatcher?: Function
+  createMatcher?: Function,
+  passRouterStateToReducer?: bool
 };
 
 export default ({
   routes: nestedRoutes,
   history,
   location,
-  createMatcher = matcherFactory
+  createMatcher = matcherFactory,
+  passRouterStateToReducer = false
 }: StoreEnhancerArgs) => {
   validateRoutes(nestedRoutes);
   const routes = flattenRoutes(nestedRoutes);
@@ -36,7 +38,8 @@ export default ({
     initialState: State,
     enhancer: StoreEnhancer
   ) => {
-    const enhancedReducer = attachRouterToReducer(reducer);
+    const enhancedReducer =
+      attachRouterToReducer(passRouterStateToReducer)(reducer);
 
     const matchRoute = createMatcher(routes);
     const matchWildcardRoute = createMatcher(routes, true);


### PR DESCRIPTION
So I did  big dumb thing in `v11.1.0` by breaking typical usage of `combineReducers`. Since `combineReducers` filters out any keys it doesn't expect, router state never even gets to the store.

This PR makes passing router state optional, with the default case supporting `combineReducers`. I'll document this as a feature in ADVANCED.md soon.

/cc @baer @Aweary 