### PR TITLE
greedy route matching

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -2,6 +2,8 @@
 import type { Location } from 'history';
 
 import React, { Component, PropTypes } from 'react';
+import matchCache from './match-cache';
+import generateId from './util/generate-id';
 
 type RelativeProps = {
   location: Location,
@@ -42,6 +44,11 @@ const absolute = (ComposedComponent: ReactClass<*>) => {
 
 const relative = (ComposedComponent: ReactClass<*>) => {
   class RelativeFragment extends Component {
+    constructor() {
+      super();
+      this.id = generateId();
+    }
+
     getChildContext() {
       return {
         // Append the parent route if this isn't the first
@@ -50,15 +57,17 @@ const relative = (ComposedComponent: ReactClass<*>) => {
           this.context.parentRoute !== '/' &&
           this.context.parentRoute !== this.props.forRoute
             ? `${this.context.parentRoute}${this.props.forRoute}`
-            : this.props.forRoute
+            : this.props.forRoute,
+        parentId: this.id
       };
     }
 
     props: RelativeProps;
+    id: string;
 
     render() {
       const { children, forRoute, ...rest } = this.props;
-      const { router, parentRoute } = this.context;
+      const { router, parentRoute, parentId } = this.context;
       const { store } = router;
 
       const location = store.getState().router;
@@ -68,6 +77,7 @@ const relative = (ComposedComponent: ReactClass<*>) => {
 
       return (
         <ComposedComponent
+          parentId={parentId}
           location={location}
           matchRoute={store.matchWildcardRoute}
           forRoute={forRoute && `${routePrefix}${forRoute}`}
@@ -81,18 +91,22 @@ const relative = (ComposedComponent: ReactClass<*>) => {
   // Consumes this context...
   RelativeFragment.contextTypes = {
     router: PropTypes.object,
-    parentRoute: PropTypes.string
+    parentRoute: PropTypes.string,
+    parentId: PropTypes.string
   };
 
   // ...and provides this context.
   RelativeFragment.childContextTypes = {
-    parentRoute: PropTypes.string
+    parentRoute: PropTypes.string,
+    parentId: PropTypes.string
   };
 
   return RelativeFragment;
 };
 
-type Props = AbsoluteProps | RelativeProps;
+type Props = AbsoluteProps & {
+  parentId?: string
+};
 
 const Fragment = (props: Props) => {
   const {
@@ -100,16 +114,16 @@ const Fragment = (props: Props) => {
     matchRoute,
     forRoute,
     withConditions,
-    children
+    children,
+    parentId
   } = props;
 
   const matchResult = matchRoute(location.pathname, forRoute);
 
-  if (!matchResult) { return null; }
-
   if (
-    forRoute &&
-    matchResult.route !== forRoute
+    !matchResult ||
+    withConditions && !withConditions(location) ||
+    forRoute && matchResult.route !== forRoute
   ) {
     return null;
   }
@@ -124,8 +138,13 @@ const Fragment = (props: Props) => {
     }
   }
 
-  if (withConditions && !withConditions(location)) {
-    return null;
+  if (parentId) {
+    const previousMatch = matchCache.get(parentId);
+    if (previousMatch && previousMatch !== forRoute) {
+      return null;
+    } else {
+      matchCache.add(parentId, forRoute);
+    }
   }
 
   return <div>{children}</div>;

--- a/src/match-cache.js
+++ b/src/match-cache.js
@@ -1,0 +1,24 @@
+// @flow
+
+const ROUTE_FALLBACK = '@ROUTE_FALLBACK';
+
+export class MatchCache {
+  _data: { [parentId: string]: string };
+  constructor() {
+    this._data = {};
+  }
+
+  add(parentId: string, route: ?string) : void {
+    this._data[parentId] = route || ROUTE_FALLBACK;
+  }
+
+  get(parentId: string) : null | string {
+    return this._data[parentId] || null;
+  }
+
+  clear() : void {
+    this._data = {};
+  }
+}
+
+export default new MatchCache();

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -12,6 +12,8 @@ import { default as matcherFactory } from './create-matcher';
 import attachRouterToReducer from './reducer-enhancer';
 import { locationDidChange } from './action-creators';
 
+import matchCache from './match-cache';
+
 import validateRoutes from './util/validate-routes';
 import flattenRoutes from './util/flatten-routes';
 
@@ -61,6 +63,7 @@ export default ({
     history.listen(newLocation => {
       /* istanbul ignore else */
       if (newLocation) {
+        matchCache.clear();
         store.dispatch(locationDidChange({
           location: newLocation, matchRoute
         }));

--- a/src/util/generate-id.js
+++ b/src/util/generate-id.js
@@ -1,0 +1,11 @@
+/**
+ * Returns a psuedo-unique identifier used by fragments
+ * to track match status within MatchCache.
+ * @returns {String} id
+ * @flow
+ */
+export default (): string => {
+  const radix = 16;
+  const length = 8;
+  return (Math.random() * Date.now()).toString(radix).slice(0, length);
+};

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -17,6 +17,17 @@ export default flattenRoutes({
     name: '3spooky5me'
   },
   '/': {
+    '/play': {
+      name: 'play',
+      '/c': {
+        name: 'c',
+        '/:code': {
+          '/code': {
+            name: 'code'
+          }
+        }
+      }
+    },
     '/this': {
       name: 'this',
       '/is': {

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -196,6 +196,40 @@ describe('RelativeFragment', () => {
     });
   });
 
+  it('does greedy matching', () => {
+    const wrapper = mount(
+      <RelativeFragment forRoute='/play'>
+      <RelativeFragment forRoute='/c/:code'>
+        <p>fist</p>
+      </RelativeFragment>
+      <RelativeFragment forRoute='/c'>
+        <p>second</p>
+      </RelativeFragment>
+      <div>
+        <ul>
+          <li>
+          <RelativeFragment forRoute='/c/:code'>
+            <p>third</p>
+          </RelativeFragment>
+          </li>
+        </ul>
+      </div>
+      <RelativeFragment forRoute='/c/code'>
+        <p>fourth</p>
+      </RelativeFragment>
+      </RelativeFragment>,
+      fakeContext({
+        pathname: '/play/c/code',
+        route: '/play/c/:code'
+      })
+    );
+
+    expect(wrapper.containsMatchingElement(<p>fist</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>second</p>)).to.be.false;
+    expect(wrapper.containsMatchingElement(<p>third</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>fourth</p>)).to.be.false;
+  });
+
   describe('basic page-by-page routing', () => {
     // eslint-disable-next-line no-extra-parens
     const element = (
@@ -203,38 +237,38 @@ describe('RelativeFragment', () => {
         <h1>App Title</h1>
         <RelativeFragment forRoute='/cheese'>
           <p>Cheese</p>
-          <RelativeFragment forRoute='/:type'>
-            <p>Cheese Type</p>
-          </RelativeFragment>
           <RelativeFragment forRoute='/gifs'>
             <p>Cheese Gifs</p>
+          </RelativeFragment>
+          <RelativeFragment forRoute='/:type'>
+            <p>Cheese Type</p>
           </RelativeFragment>
         </RelativeFragment>
         <RelativeFragment forRoute='/dog'>
           <p>Dog</p>
-          <RelativeFragment forRoute='/:type'>
-            <p>Dog Type</p>
-          </RelativeFragment>
           <RelativeFragment forRoute='/gifs'>
             <p>Dog Gifs</p>
+          </RelativeFragment>
+          <RelativeFragment forRoute='/:type'>
+            <p>Dog Type</p>
           </RelativeFragment>
         </RelativeFragment>
         <RelativeFragment forRoute='/cat'>
           <p>Cat</p>
-          <RelativeFragment forRoute='/:type'>
-            <p>Cat Type</p>
-          </RelativeFragment>
           <RelativeFragment forRoute='/gifs'>
             <p>Cat Gifs</p>
+          </RelativeFragment>
+          <RelativeFragment forRoute='/:type'>
+            <p>Cat Type</p>
           </RelativeFragment>
         </RelativeFragment>
         <RelativeFragment forRoute='/hipster'>
           <p>Hipster</p>
-          <RelativeFragment forRoute='/:type'>
-            <p>Hipster Type</p>
-          </RelativeFragment>
           <RelativeFragment forRoute='/gifs'>
             <p>Hipster Gifs</p>
+          </RelativeFragment>
+          <RelativeFragment forRoute='/:type'>
+            <p>Hipster Type</p>
           </RelativeFragment>
         </RelativeFragment>
       </RelativeFragment>

--- a/test/match-cache.spec.js
+++ b/test/match-cache.spec.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { MatchCache } from '../src/match-cache';
+let cache;
+
+describe('MatchCache', () => {
+
+  beforeEach(() => {
+    cache = new MatchCache();
+  });
+
+  it('allows items to be set', () => {
+    cache.add('foo', 'bar');
+    expect(cache._data).to.deep.equal({ foo: 'bar' });
+  });
+
+  it('allows items to be retrieved', () => {
+    cache.add('foo', 'bar');
+    const foo = cache.get('foo');
+    expect(foo).to.equal('bar');
+  });
+
+  it('is clearable', () => {
+    cache.add('foo', 'bar');
+    cache.clear();
+    expect(cache._data).to.deep.equal({});
+  });
+});


### PR DESCRIPTION
Implements greedy matching for `<RelativeFragment/>` by providing unique ids to fragments and tracking which route has been matched for each fragment, so sibling fragments know whether or not to render.

This would be a breaking change and require a major release as far as I can tell.

I'm still working on reviewing all the implications of this new matching system, but figured I'd open the PR for review 👍 

/cc @tptee 🎉 