### PR TITLE
Hapi support with hapi-router

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,11 +1,13 @@
 # Advanced Docs
 
 ## Server Rendering
-`redux-little-router` supports React server rendering with an Express adapter, with plans to support Hapi in the future.
+`redux-little-router` supports React server rendering with an Express or Hapi adapter.
 
 Make sure to read http://redux.js.org/docs/recipes/ServerRendering.html to understand how the server/client Redux boilerplate works.
 
 Here's what the setup looks like on the server (assuming Node 4 LTS):
+
+### Express
 
 ```js
 const express = require('express');
@@ -56,6 +58,60 @@ app.use('/*', (req, res) => {
   // Don't forget to attach your ESCAPED initialState to
   // a script tag in your template that attaches to
   // something like window.__INITIAL_STATE.
+});
+```
+
+### Hapi
+
+```js
+const hapi = require('hapi');
+const server = new Hapi.Server();
+const routerForHapi = require('redux-little-router')
+  .routerForHapi;
+
+const redux = require('redux');
+const createStore = redux.createStore;
+const compose = redux.compose;
+const applyMiddleware = redux.applyMiddleware;
+
+const routes = {
+  '/': {
+    '/whatever': {
+      title: 'Whatever'
+    }
+  }
+};
+
+server.route({
+	method: 'GET',
+	path: '/{wild*}',
+	handler: (request, reply) => {
+		// Create the Redux store, passing in the Hapi
+		// request to the routerForHapi factory.
+
+		const router = routerForHapi({
+			routes,
+			request
+		})
+
+		const store = createStore(
+			state => state,
+			{ what: 'ever' },
+			compose(
+				router.routerEnhancer,
+				applyMiddleware(
+					router.routerMiddleware
+				)
+			)
+		);
+
+		// ...then renderToString() your components as usual,
+		// passing your new store to your <Provider> component.
+		// 
+		// Don't forget to attach your ESCAPED initialState to
+		// a script tag in your template that attaches to
+		// something like window.__INITIAL_STATE.
+	}
 });
 ```
 

--- a/src/hapi-router.js
+++ b/src/hapi-router.js
@@ -1,0 +1,39 @@
+// @flow
+import createMemoryHistory from 'history/lib/createMemoryHistory';
+import useQueries from 'history/lib/useQueries';
+
+import installRouter from './store-enhancer';
+import routerMiddleware from './middleware';
+
+type ServerRouterArgs = {
+  routes: Object,
+  request: {
+    path: string,
+    url: string,
+    query: {[key: string]: string}
+  },
+  passRouterStateToReducer?: bool
+};
+
+export default ({
+  routes,
+  request,
+  passRouterStateToReducer = false
+}: ServerRouterArgs) => {
+  const history = useQueries(createMemoryHistory)();
+
+  const location = history.createLocation({
+    pathname: request.path,
+    query: request.query
+  });
+
+  return {
+    routerEnhancer: installRouter({
+      routes,
+      history,
+      location,
+      passRouterStateToReducer
+    }),
+    routerMiddleware: routerMiddleware({ history })
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 import routerForBrowser from './browser-router';
 import routerForExpress from './express-router';
+import routerForHapi from './hapi-router';
 import createStoreWithRouter from './store-enhancer';
 import routerMiddleware from './middleware';
 import { locationDidChange, initializeCurrentLocation } from './action-creators';
@@ -27,6 +28,7 @@ export {
   // High-level Redux API
   routerForBrowser,
   routerForExpress,
+  routerForHapi,
   routerMiddleware,
   initializeCurrentLocation,
 

--- a/test/express-router.spec.js
+++ b/test/express-router.spec.js
@@ -10,7 +10,7 @@ import routes from './fixtures/routes';
 chai.use(sinonChai);
 
 describe('Express router', () => {
-  it('creates a browser store enhancer using window.location', () => {
+  it('creates a server store enhancer using Express request object', () => {
     const { routerEnhancer } = routerForExpress({
       routes,
       request: {

--- a/test/hapi-router.spec.js
+++ b/test/hapi-router.spec.js
@@ -1,0 +1,33 @@
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+
+import { createStore } from 'redux';
+
+import routerForHapi from '../src/hapi-router';
+
+import routes from './fixtures/routes';
+
+chai.use(sinonChai);
+
+describe('Express router', () => {
+  it('creates a server store enhancer using Hapi request object', () => {
+    const { routerEnhancer } = routerForHapi({
+      routes,
+      request: {
+        path: '/home',
+        query: { get: 'schwifty' }
+      }
+    });
+    const store = createStore(
+      state => state,
+      {},
+      routerEnhancer
+    );
+    const state = store.getState();
+    expect(state).to.have.deep.property('router.pathname', '/home');
+    expect(state).to.have.deep.property('router.search', '?get=schwifty');
+    expect(state).to.have.deep.property('router.query')
+      .that.deep.equals({ get: 'schwifty' });
+  });
+
+});


### PR DESCRIPTION
This PR adds a `routerForHapi` that parallels the implementation of `routerForExpress`. The main difference is that Hapi doesn't currently support sub-routes with a `basename`/`baseUrl`, so the `routerForHapi` doesn't need to support `useBasename` from the history lib. The shape of a Hapi request is otherwise similar-enough to an Express request that there's nothing else needed to instantiate the history `location`.

I've confirmed this works in a currently-private project.