### PR TITLE
Fix multiple history v4 upgrade regressions

### DIFF
--- a/src/browser-router.js
+++ b/src/browser-router.js
@@ -27,6 +27,7 @@ export default ({
   const descriptor = basename
     ? { pathname, basename, search }
     : { pathname, search };
+
   const location = createLocation(descriptor);
 
   return {

--- a/src/link.js
+++ b/src/link.js
@@ -108,11 +108,13 @@ const Link = (
   } = props;
 
   const { router } = context;
+  const { router: currentLocation } = router.store.getState();
+  const { basename } = currentLocation;
 
   const locationDescriptor =
     resolveQueryForLocation({
       linkLocation: normalizeLocation(href),
-      currentLocation: router.store.getState().router,
+      currentLocation,
       persistQuery
     });
 
@@ -120,7 +122,7 @@ const Link = (
 
   return (
     <a
-      href={normalizeHref(location)}
+      href={normalizeHref({ ...location, basename })}
       onClick={e => handleClick({
         e,
         location,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -20,10 +20,17 @@ export default (state: ?Location | Object = {}, action: Action) => {
     if (state) {
       // eslint-disable-next-line no-unused-vars
       const { previous, ...oldState } = state;
-      return {
+
+      const nextState = {
         ...action.payload,
         previous: oldState
       };
+
+      // reuse the initial basename if not provided
+      return oldState.basename ? {
+        basename: oldState.basename,
+        ...nextState
+      } : nextState;
     }
   }
   return state;

--- a/src/util/create-location.js
+++ b/src/util/create-location.js
@@ -8,7 +8,8 @@ export default (path, state, key, currentLocation) => {
   const { query, basename } = path;
   const { search } = vanillaLocation;
 
-  const resolvedSearch = search || (query && `?${qs.stringify(query)}`) || '';
+  const resolvedSearch = search ||
+    (query && Object.keys(query).length && `?${qs.stringify(query)}`) || '';
   const resolvedQuery = query || qs.parse(search);
 
   const location = {

--- a/test/create-location.spec.js
+++ b/test/create-location.spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import createLocation from '../src/util/create-location';
+
+describe('createLocation', () => {
+  it('ignores empty query objects', () => {
+    const result = createLocation({
+      pathname: '/',
+      query: {}
+    });
+
+    expect(result).to.have.property('search', '');
+  });
+});

--- a/test/link.spec.js
+++ b/test/link.spec.js
@@ -181,6 +181,7 @@ describe('Router link component', () => {
           });
       });
     });
+
     describe('Rendering', () => {
       it('renders an <a /> with the correct href attribute', () => {
         const hrefs = [
@@ -199,6 +200,27 @@ describe('Router link component', () => {
           );
           expect(createLocationStub).to.have.been.calledOnce;
           expect(wrapper.find('a').prop('href')).to.equal(href);
+        });
+      });
+
+      it('renders an <a /> with the correct href attribute using a basename', () => {
+        const hrefs = [
+          '/path',
+          '/path?key=value',
+          'path/with/nested/routes'
+        ];
+        hrefs.forEach(href => {
+          const createLocationStub = sandbox.stub().returns({
+            basename: '/base',
+            pathname: href,
+            search: ''
+          });
+          const wrapper = shallow(
+            <Link href={href} createLocation={createLocationStub} />,
+            fakeContext({ basename: '/base' })
+          );
+          expect(createLocationStub).to.have.been.calledOnce;
+          expect(wrapper.find('a').prop('href')).to.equal(`/base${href}`);
         });
       });
 
@@ -224,6 +246,32 @@ describe('Router link component', () => {
           );
           expect(createLocationStub).to.have.been.calledOnce;
           expect(wrapper.find('a').prop('href')).to.equal(expected[index]);
+        });
+      });
+
+      it('parses and renders location objects as hrefs using a basename', () => {
+        const expected = [
+          '/path',
+          '/path?key=value',
+          'path/with/nested/routes'
+        ];
+        const locations = [
+          { pathname: '/path' },
+          { pathname: '/path', query: { key: 'value' } },
+          { pathname: 'path/with/nested/routes' }
+        ];
+        locations.forEach((location, index) => {
+          const createLocationStub = sandbox.stub().returns({
+            basename: '/base',
+            pathname: location.pathname,
+            search: `${location.query ? '?' : ''}${qs.stringify(location.query)}`
+          });
+          const wrapper = shallow(
+            <Link href={location} createLocation={createLocationStub} />,
+            fakeContext({ basename: '/base' })
+          );
+          expect(createLocationStub).to.have.been.calledOnce;
+          expect(wrapper.find('a').prop('href')).to.equal(`/base${expected[index]}`);
         });
       });
     });

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -32,6 +32,41 @@ describe('Router reducer', () => {
     });
   });
 
+  it('persists the initial basename after subsequent navigations', () => {
+    const action = {
+      type: LOCATION_CHANGED,
+      payload: {
+        params: {},
+        result: 'rofl',
+        url: '/rofl',
+        pathname: '/rofl',
+        action: 'PUSH',
+        state: {
+          bork: 'bork'
+        }
+      }
+    };
+
+    const result = routerReducer({
+      basename: '/base'
+    }, action);
+
+    expect(result).to.deep.equal({
+      basename: '/base',
+      params: {},
+      result: 'rofl',
+      url: '/rofl',
+      pathname: '/rofl',
+      action: 'PUSH',
+      state: {
+        bork: 'bork'
+      },
+      previous: {
+        basename: '/base'
+      }
+    });
+  });
+
   it('does nothing if the action pathname is the same as the existing', () => {
     const action = {
       type: LOCATION_CHANGED,

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -15,6 +15,7 @@ export const captureErrors = (done, assertions) => {
 
 export const fakeStore = ({
   assertion,
+  basename,
   pathname = '/home/messages/b-team',
   query = { test: 'ing' },
   route = '/home/messages/:team',
@@ -28,6 +29,7 @@ export const fakeStore = ({
     getState() {
       return {
         router: {
+          basename,
           pathname,
           query,
           search: '?test=ing',
@@ -50,6 +52,7 @@ export const fakeStore = ({
 
 export const fakeContext = ({
   assertion,
+  basename,
   pathname = '/home/messages/b-team',
   route = '/home/messages/:team',
   query = { test: 'ing' }
@@ -58,6 +61,7 @@ export const fakeContext = ({
     router: {
       store: fakeStore({
         assertion,
+        basename,
         pathname,
         query,
         route


### PR DESCRIPTION
Fixes regressions introduced in #125:

- `<Link>` didn't append `basename`s to `href`s
- `basename` disappeared from the router state after first user-initiated navigation
- Empty query objects appended an extraneous question mark to URLs

/cc @baer @divmain @scottnonnenberg 