### PR TITLE
Tests and fixes for empty query string on back button and others.

### DIFF
--- a/src/browser-router.js
+++ b/src/browser-router.js
@@ -8,22 +8,17 @@ import routerMiddleware from './middleware';
 type BrowserRouterArgs = {
   routes: Object,
   basename: string,
-  getLocation: () => Location,
   passRouterStateToReducer?: bool
 };
-
-/* istanbul ignore next: unstubbable! */
-const realLocation = () => window.location;
 
 export default ({
   routes,
   basename,
-  getLocation = realLocation,
   passRouterStateToReducer = false
 }: BrowserRouterArgs) => {
   const history = createBrowserHistory({ basename });
 
-  const { pathname, search } = getLocation();
+  const { pathname, search } = history.location;
   const descriptor = basename
     ? { pathname, basename, search }
     : { pathname, search };

--- a/src/fragment.js
+++ b/src/fragment.js
@@ -80,7 +80,7 @@ const relative = (ComposedComponent: ReactClass<*>) => {
           parentId={parentId}
           location={location}
           matchRoute={store.matchWildcardRoute}
-          forRoute={forRoute && `${routePrefix}${forRoute}`}
+          forRoute={(forRoute || forRoute === '') && `${routePrefix}${forRoute}`}
           children={children}
           {...rest}
         />

--- a/src/store-enhancer.js
+++ b/src/store-enhancer.js
@@ -7,6 +7,7 @@ import type {
 } from 'redux';
 
 import type { History } from 'history';
+import qs from 'query-string';
 
 import { default as matcherFactory } from './create-matcher';
 import attachRouterToReducer from './reducer-enhancer';
@@ -64,6 +65,7 @@ export default ({
       /* istanbul ignore else */
       if (newLocation) {
         matchCache.clear();
+        newLocation.query = qs.parse(newLocation.search);
         store.dispatch(locationDidChange({
           location: newLocation,
           matchRoute

--- a/test/browser-router.spec.js
+++ b/test/browser-router.spec.js
@@ -3,20 +3,21 @@ import sinonChai from 'sinon-chai';
 
 import { createStore } from 'redux';
 
+import jsdom from 'jsdom';
+
 import routerForBrowser from '../src/browser-router';
 
 import routes from './fixtures/routes';
 
 chai.use(sinonChai);
 
+/*global window*/
+
 describe('Browser router', () => {
   it('creates a browser store enhancer using window.location', () => {
+    jsdom.changeURL(window, 'https://example.com/home?get=schwifty');
     const { routerEnhancer } = routerForBrowser({
-      routes,
-      getLocation: () => ({
-        pathname: '/home',
-        search: '?get=schwifty'
-      })
+      routes
     });
     const store = createStore(
       state => state,
@@ -31,13 +32,11 @@ describe('Browser router', () => {
   });
 
   it('supports basenames', () => {
+    jsdom.changeURL(window, 'https://example.com/cob-planet/home?get=schwifty');
+
     const { routerEnhancer } = routerForBrowser({
       routes,
-      basename: '/cob-planet',
-      getLocation: () => ({
-        pathname: '/home',
-        search: '?get=schwifty'
-      })
+      basename: '/cob-planet'
     });
     const store = createStore(
       state => state,

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -230,6 +230,30 @@ describe('RelativeFragment', () => {
     expect(wrapper.containsMatchingElement(<p>fourth</p>)).to.be.false;
   });
 
+  it('renders default route if no others match', () => {
+    const wrapper = mount(
+      <RelativeFragment forRoute='/play'>
+        <RelativeFragment forRoute='/c/:code'>
+          <p>fist</p>
+        </RelativeFragment>
+        <RelativeFragment forRoute='/c'>
+          <p>second</p>
+        </RelativeFragment>
+        <RelativeFragment forRoute=''>
+          <p>default</p>
+        </RelativeFragment>
+      </RelativeFragment>,
+      fakeContext({
+        pathname: '/play',
+        route: '/play'
+      })
+    );
+
+    expect(wrapper.containsMatchingElement(<p>fist</p>)).to.be.false;
+    expect(wrapper.containsMatchingElement(<p>second</p>)).to.be.false;
+    expect(wrapper.containsMatchingElement(<p>default</p>)).to.be.true;
+  });
+
   describe('basic page-by-page routing', () => {
     // eslint-disable-next-line no-extra-parens
     const element = (

--- a/test/store-enhancer.spec.js
+++ b/test/store-enhancer.spec.js
@@ -125,6 +125,22 @@ describe('Router store enhancer', () => {
     });
   });
 
+  it('updates pathname and query in the state tree on browser location change', () => {
+    const { store, historyStub } = fakeStore();
+    historyStub.listen.yield({
+      pathname: '/home/messages',
+      search: 'yo=yo',
+      hash: ''
+    });
+
+    // this would be simpilar with Chai 4 and expect(...).to.deep.include({...})
+    // https://github.com/chaijs/chai/issues/781
+    const state = store.getState();
+    expect(state).to.have.deep.property('router.pathname', '/home/messages');
+    expect(state).to.have.deep.property('router.query.yo', 'yo');
+    expect(state).to.have.deep.property('router.result.name', 'messages');
+  });
+
   it('merges user-provided initial state with initial routing state', () => {
     const { store } = fakeStore({
       initialState: {


### PR DESCRIPTION
This addresses #127 and two more issues I had:
* When using the back button, the action initiated didn't include the query object while the action does contain query for other types of navigation.
* When the page was pre-rendered on the server, the `pathname` was set wrong.
* Without allowing an empty string, there was no way to have a default route nested under other `RelativeFragment`.

Tests are included, and they are a commit before the fix, so they can be shown as failing, then fixed.