### PR TITLE
Upgrades the peer dependency for react-redux to 5.0 (optionally 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
     "react-dom": "^0.14.0 || ^15.0.0-0",
-    "react-redux": "^4.0.0",
+    "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.0.0"
   },
   "nyc": {


### PR DESCRIPTION
I have been seeing a peer dependency warning re. react-redux, and this PR bumps the version but maintains the older version (as established with the other peer dependencies). After a period of time—once it's fairly certain that 5.0 is in actuality a non-breaking release—the 4.0 option could be removed.

From the commit:

Though react-redux's [5.0.0 release is backwards compatible with 4.0.0])(https://github.com/reactjs/react-redux/releases/tag/v5.0.0), in the spirit of supporting multiple versions as with the react and react-dom dependency, this change allows either version to be used. 

This will silence the peer dependency warning.