### PR TITLE
Allow url-pattern options to be specified on routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import yourReducer from './your-app';
 // Useful for page titles and other route-specific data.
 
 // Uses https://github.com/snd/url-pattern for URL matching
-// and parameter extraction.
+// and parameter extraction. options can be set in patternOptions
 const routes = {
   '/messages': {
     title: 'Message'
@@ -62,6 +62,7 @@ const routes = {
       title: 'Biographies',
       '/:name': {
         title: 'Biography for:'
+        patternOptions: {segmentValueCharset: 'a-zA-Z_'},
       }
     }
   }

--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -71,7 +71,7 @@ export default (routes: Object, wildcard: bool = false) => {
       pattern: new UrlPattern(
         // Prepend with wildcards if requested
         `${route}${wildcard && '*' || ''}`
-      ),
+      , routes[route].patternOptions || {}),
       result: routes[route]
     }));
 


### PR DESCRIPTION
`url-pattern` works neatly for specifying parameters. However, its default options make various presumptions (notably what characters can be included in a parameter). See #107, #41 for previous issues relating to this

This patch allows a simple extra `patternOptions` to be specified on a route; these options are passed through directly to the pattern on creation.