### PR TITLE
Add support for matching nested index (#114)

### DIFF
--- a/src/components/fragment.js
+++ b/src/components/fragment.js
@@ -8,7 +8,9 @@ import generateId from '../util/generate-id';
 type Props = {
   location: Location,
   matchRoute: Function,
+  matchWildcardRoute: Function,
   forRoute?: string,
+  parentRoute?: string,
   withConditions?: (location: Location) => boolean,
   parentId?: string,
   children: React.Element<*>
@@ -53,8 +55,10 @@ const relativePaths = (ComposedComponent: ReactClass<*>) => {
         <ComposedComponent
           parentId={parentId}
           location={location}
-          matchRoute={store.matchWildcardRoute}
-          forRoute={forRoute && `${routePrefix}${forRoute}`}
+          matchRoute={store.matchRoute}
+          matchWildcardRoute={store.matchWildcardRoute}
+          parentRoute={parentRoute}
+          forRoute={forRoute && `${routePrefix}${forRoute === '/' && parentId ? '' : forRoute}`}
           children={children}
           {...rest}
         />
@@ -82,13 +86,16 @@ const Fragment = (props: Props) => {
   const {
     location,
     matchRoute,
+    matchWildcardRoute,
     forRoute,
     withConditions,
     children,
-    parentId
+    parentId,
+    parentRoute
   } = props;
 
-  const matchResult = matchRoute(location.pathname, forRoute);
+  const matcher = (forRoute === parentRoute) ? matchRoute : matchWildcardRoute;
+  const matchResult = matcher(location.pathname, forRoute);
 
   if (
     !matchResult ||

--- a/test/components/fragment.spec.js
+++ b/test/components/fragment.spec.js
@@ -138,6 +138,110 @@ describe('Fragment', () => {
     expect(wrapper.containsMatchingElement(<p>fourth</p>)).to.be.false;
   });
 
+  it('matches nested index', () => {
+    const wrapper = mount(
+      <Fragment forRoute='/foo'>
+        <div>
+          <p>first</p>
+          <Fragment forRoute='/'>
+            <p>second</p>
+          </Fragment>
+          <Fragment forRoute='/bar'>
+            <p>third</p>
+          </Fragment>
+        </div>
+      </Fragment>,
+      fakeContext({
+        pathname: '/foo',
+        route: '/foo'
+      })
+    );
+
+    expect(wrapper.containsMatchingElement(<p>first</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>second</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>third</p>)).to.be.false;
+  });
+
+  it('matches double nested index', () => {
+    const wrapper = mount(
+      <Fragment forRoute='/foo'>
+        <Fragment forRoute='/bar'>
+          <div>
+            <p>first</p>
+            <Fragment forRoute='/'>
+              <p>second</p>
+            </Fragment>
+            <Fragment forRoute='/you'>
+              <p>third</p>
+            </Fragment>
+          </div>
+        </Fragment>
+      </Fragment>,
+      fakeContext({
+        pathname: '/foo/bar',
+        route: '/foo/bar'
+      })
+    );
+
+    expect(wrapper.containsMatchingElement(<p>first</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>second</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>third</p>)).to.be.false;
+  });
+
+  it('doesnt match nested index', () => {
+    const wrapper = mount(
+      <Fragment forRoute='/foo'>
+        <div>
+          <p>first</p>
+          <Fragment forRoute='/'>
+            <p>second</p>
+          </Fragment>
+          <Fragment forRoute='/bar'>
+            <p>third</p>
+          </Fragment>
+        </div>
+      </Fragment>,
+      fakeContext({
+        pathname: '/foo/bar',
+        route: '/foo/bar'
+      })
+    );
+    expect(wrapper.containsMatchingElement(<p>first</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>second</p>)).to.be.false;
+    expect(wrapper.containsMatchingElement(<p>third</p>)).to.be.true;
+  });
+
+  it('doesnt match double nested index', () => {
+    const wrapper = mount(
+      <Fragment forRoute='/foo'>
+        <Fragment forRoute='/bar'>
+          <div>
+            <p>first</p>
+            <Fragment forRoute='/'>
+              <p>second</p>
+            </Fragment>
+            <Fragment forRoute='/you'>
+              <p>third</p>
+            </Fragment>
+            <Fragment forRoute='/me'>
+              <p>fourth</p>
+            </Fragment>
+          </div>
+        </Fragment>
+      </Fragment>,
+      fakeContext({
+        pathname: '/foo/bar/you',
+        route: '/foo/bar/you'
+      })
+    );
+
+    expect(wrapper.containsMatchingElement(<p>first</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>second</p>)).to.be.false;
+    expect(wrapper.containsMatchingElement(<p>third</p>)).to.be.true;
+    expect(wrapper.containsMatchingElement(<p>fourth</p>)).to.be.false;
+  });
+
+
   describe('basic page-by-page routing', () => {
     // eslint-disable-next-line no-extra-parens
     const element = (

--- a/test/test-util/fixtures/routes.js
+++ b/test/test-util/fixtures/routes.js
@@ -57,6 +57,12 @@ export default flattenRoutes({
     '/hipster': {
       '/gifs': {},
       '/:type': {}
+    },
+    '/foo': {
+      '/bar': {
+        '/you': {},
+        '/me': {}
+      }
     }
   }
 });


### PR DESCRIPTION
This addresses #114 by supporting nested relative index links `/`. I suppose it is a bit of a special case, but at the same time a fairly prevalent route pattern. So, here is my suggested fix. Thanks for all your work on this @tptee!

