### PR TITLE
Changes app.use to app.get in the Advanced Docs to fix issue where pa…

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -29,7 +29,7 @@ const routes = {
   }
 };
 
-app.use('/*', (req, res) => {
+app.get('/*', (req, res) => {
   // Create the Redux store, passing in the Express
   // request to the routerForExpress factory.
   // 


### PR DESCRIPTION
Changes app.use to app.get in the Advanced Docs to fix issue where pathname is not getting set correctly when the request contains a second level route