### PR TITLE
Added a merge query option

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -12,6 +12,14 @@ type ResolverArgs = {
   options: LocationOptions
 };
 
+
+const mergeSearch = (oldSearch, newSearch) => {
+  if (oldSearch && newSearch) {
+    return oldSearch + newSearch.replace('?', '&');
+  }
+  return oldSearch || newSearch;
+};
+
 const resolveQuery = ({
   oldLocation,
   newLocation,
@@ -52,19 +60,13 @@ const resolveQuery = ({
           ...newLocation.query
         },
         search: mergeSearch(oldSearch, newLocation.search)
-      }
-    }
+      },
+      options
+    };
   }
 
   return { oldLocation, newLocation, options };
 };
-
-const mergeSearch = (oldSearch, newSearch) => {
-  if (oldSearch && newSearch) {
-    return oldSearch + newSearch.replace('?', '&');
-  }
-  return oldSearch || newSearch;
-}
 
 const resolveBasename = ({
   oldLocation,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -38,8 +38,33 @@ const resolveQuery = ({
     };
   }
 
+  // Only merge the previous query if it exists
+  if (
+    options.mergeQuery &&
+    oldQuery
+  ) {
+    return {
+      oldLocation,
+      newLocation: {
+        ...newLocation,
+        query: {
+          ...oldQuery,
+          ...newLocation.query
+        },
+        search: mergeSearch(oldSearch, newLocation.search)
+      }
+    }
+  }
+
   return { oldLocation, newLocation, options };
 };
+
+const mergeSearch = (oldSearch, newSearch) => {
+  if (oldSearch && newSearch) {
+    return oldSearch + newSearch.replace('?', '&');
+  }
+  return oldSearch || newSearch;
+}
 
 const resolveBasename = ({
   oldLocation,

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -126,6 +126,49 @@ describe('Router reducer', () => {
         },
         search: '?clap=please',
         options: {
+          mergeQuery: true
+        }
+      }
+    };
+
+    const result = reducer()({
+      pathname: '/waffle',
+      query: {
+        please: 'clap'
+      },
+      search: '?please=clap'
+    }, action);
+
+    expect(result).to.deep.equal({
+      pathname: '/rofl',
+      query: {
+        clap: 'please',
+        please: 'clap'
+      },
+      search: '?please=clap&clap=please',
+      options: {
+        mergeQuery: true
+      },
+      previous: {
+        pathname: '/waffle',
+        query: {
+          please: 'clap'
+        },
+        search: '?please=clap'
+      }
+    });
+  });
+
+  it('merges the old query with the new queries with mergeQuery', () => {
+    const action = {
+      type: LOCATION_CHANGED,
+      payload: {
+        pathname: '/rofl',
+        query: {
+          clap: 'please'
+        },
+        search: '?clap=please',
+        options: {
           persistQuery: true
         }
       }


### PR DESCRIPTION
Originally, this is how I assumed `persistQuery` worked. Let's say my current url is:

> http://www.abc.com?search=abc&filter=new

If I call 

```
push(
    { query: { search: 'xyz' } }, { mergeQuery: true }
)
```

my url becomes:

> http://www.abc.com?search=xyz&filter=new

This is nice because it allows my component to only have to have knowledge of the query parameter he's interested in. 

