### PR TITLE
Link passes target to underlying <a> element

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -93,6 +93,7 @@ const Link = (
     <a
       href={stringifyHref(href, basename)}
       onClick={clickHandler}
+      target={target}
       {...rest}
     >
       {children}


### PR DESCRIPTION
Link now passes target to underlying <a> element. Fixes #164 