### PR TITLE
Alternate reducer composition (Docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ const {
 
 const clientOnlyStore = createStore(
   combineReducers({ router: reducer, yourReducer }),
+  // Or alternatively, if yourReducer is already the top-level reducers.
+  // (state, action) => {
+  //   return {
+  //     ...yourReducer(state, action),
+  //     router: routerReducer(state, action)
+  //   };
+  // },
   initialState,
   compose(enhancer, applyMiddleware(middleware))
 );


### PR DESCRIPTION
It seems likely that most people will have an app reducer already combined at the point at which the store is created, having imported their top-level precombined reducer.

Happy to reformulate this into an alternate section as opposed to a comment or whatever you suggest. I think the current example will likely lead people to introducing an extra level into their reducers that they did not want.