### PR TITLE
Merge old and new queries on persistQuery

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,9 +1,11 @@
 // @flow
 import type { Location, LocationOptions, LocationAction } from './types';
 
+import qs from 'query-string';
+
 import { LOCATION_CHANGED, isNavigationAction } from './types';
 
-const flow = (...funcs: Array<Function>) =>
+const flow = (...funcs: Array<*>) =>
   funcs.reduce((prev, curr) => (...args) => curr(prev(...args)));
 
 type ResolverArgs = {
@@ -17,22 +19,18 @@ const resolveQuery = ({
   newLocation,
   options
 }: ResolverArgs): ResolverArgs => {
-  const { query: oldQuery, search: oldSearch } = oldLocation;
-
-  // Only use the query from state if it exists
-  // and the href doesn't provide its own query
-  if (
-    options.persistQuery &&
-    oldQuery &&
-    !newLocation.search &&
-    !newLocation.query
-  ) {
+  // Merge the old and new queries if asked to persist
+  if (options.persistQuery) {
+    const mergedQuery = {
+      ...oldLocation.query,
+      ...newLocation.query
+    };
     return {
       oldLocation,
       newLocation: {
         ...newLocation,
-        query: oldQuery,
-        search: oldSearch
+        query: mergedQuery,
+        search: `?${qs.stringify(mergedQuery)}`
       },
       options
     };

--- a/test/components/link.spec.js
+++ b/test/components/link.spec.js
@@ -281,6 +281,19 @@ describe('Link', () => {
         expect(wrapper.find('a').prop('href')).to.equal(`/base${expected[index]}`);
       });
     });
+
+    it('renders the correct href when persisting queries', () => {
+      const onClick = sandbox.stub();
+      const wrapper = mount(
+        <Link persistQuery href='/home?what=do' onClick={onClick} />,
+        fakeContext({
+          query: { persist: 'pls' }
+        })
+      );
+
+      expect(wrapper.find('a').prop('href'))
+        .to.equal('/home?persist=pls&what=do');
+    });
   });
 
   describe('PersistentQueryLink', () => {

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -121,7 +121,7 @@ describe('Router reducer', () => {
     });
   });
 
-  it('persists the previous query string if requested', () => {
+  it('persists the previous query if requested', () => {
     const reducerInstance = reducer();
 
     const navigationAction = {
@@ -180,7 +180,7 @@ describe('Router reducer', () => {
     });
   });
 
-  it('allows new queries to override persistQuery', () => {
+  it('merges old and new queries when requesting persistence', () => {
     const reducerInstance = reducer();
 
     const navigationAction = {
@@ -222,9 +222,10 @@ describe('Router reducer', () => {
     expect(result).to.deep.equal({
       pathname: '/rofl',
       query: {
-        clap: 'please'
+        clap: 'please',
+        please: 'clap'
       },
-      search: '?clap=please',
+      search: '?clap=please&please=clap',
       previous: {
         pathname: '/waffle',
         query: {


### PR DESCRIPTION
Closes #172 and #132.

`persistQuery` merges in the new query into the old query instead of blowing the old one away. Also fixes a bug where the wrong href would display when persisting queries.