### PR TITLE
Add 404 fragments

### DIFF
--- a/demo/client/demo.css
+++ b/demo/client/demo.css
@@ -58,3 +58,7 @@
 .image {
   width: 100%;
 }
+
+.noMatchImage {
+  max-width: 100%;
+}

--- a/demo/client/demo.js
+++ b/demo/client/demo.js
@@ -55,21 +55,37 @@ const Demo = ({ location }) => {
             <Link href='/dog'>Dog</Link>
             <Link href='/cat?is=cat'>Cat</Link>
             <Link href='/hipster'>Hipster</Link>
+            <Link href='/nonexistent'>My Design Skills</Link>
           </div>
 
           <div className={styles.panes}>
             {demoRoutes.map(route => (
               <Fragment key={route} forRoute={route}>
                 <div>
-                  <p>{location.result.text}</p>
+                  <p>{location.result && location.result.text}</p>
                   <Gallery
-                    images={location.result.images}
+                    images={location.result && location.result.images}
                     columns={COLUMN_COUNT}
                   />
                 </div>
               </Fragment>
             ))}
           </div>
+
+          <Fragment forRoute='/'>
+            <p>Pickum ipsum!</p>
+          </Fragment>
+
+          <Fragment forNoMatch>
+            <div>
+              <h2>FOUR O'FOUR</h2>
+              <p>Looks like you found something that doesn't exist!</p>
+              <img
+                className={styles.noMatchImage}
+                src='http://i1.kym-cdn.com/photos/images/original/001/018/866/e44.png'
+              />
+            </div>
+          </Fragment>
         </div>
       </Fragment>
     </div>

--- a/src/components/fragment.js
+++ b/src/components/fragment.js
@@ -86,6 +86,7 @@ type Props = {
   forRoute?: string,
   parentRoute?: string,
   withConditions?: (location: Location) => boolean,
+  forNoMatch?: boolean,
   parentId?: string,
   children: React.Element<*>
 };
@@ -123,6 +124,7 @@ class Fragment extends Component {
       children,
       forRoute,
       withConditions,
+      forNoMatch,
       location,
       parentRoute,
       parentId
@@ -135,7 +137,7 @@ class Fragment extends Component {
       location
     });
 
-    if (!shouldShow) {
+    if (!shouldShow && !forNoMatch) {
       return null;
     }
 


### PR DESCRIPTION
Putting a `<Fragment forNoMatch />` as the last child of a nested route allows for 404 behavior.