### PR TITLE
Support replacing static routes

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -140,3 +140,20 @@ const store = createStore(
 ```
 
 If you're using an Express sub-router, you should extract the inferred `basename` from `window.__INITIAL_STATE.router.basename` and pass it to `routerForBrowser`.
+
+## Code Splitting
+
+If you're using `Fragment`, you shouldn't have any restrictions on component-level code splitting. If you rely on static routes, you'll need to use the `replaceRoutes` action creator to update your routes after loading a component with new routes. `replaceRoutes` has no opinions on route updates and obliterates any existing routes, so you likely want to use `redux-thunk` to merge your new routes in:
+
+```js
+import { merge } from 'lodash';
+import { replaceRoutes } from 'redux-little-router';
+
+const mergeRoutes = newRoutes => (dispatch, getState) => {
+  const currentRoutes = getState().routes;
+  return dispatch(replaceRoutes(merge(currentRoutes, newRoutes)));
+}
+
+// Later, maybe in a `connect()ed component`
+loadSomeAsyncRoutes().then(routes => dispatch(mergeRoutes()))
+```

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,10 +7,13 @@ import {
   GO,
   GO_BACK,
   GO_FORWARD,
-  LOCATION_CHANGED
+  LOCATION_CHANGED,
+  REPLACE_ROUTES,
+  DID_REPLACE_ROUTES
 } from './types';
 
 import normalizeHref from './util/normalize-href';
+import flattenRoutes from './util/flatten-routes';
 
 export const push = (href: Href, options: LocationOptions = {}) => ({
   type: PUSH,
@@ -38,4 +41,18 @@ export const locationDidChange = (location: Location) => ({
 export const initializeCurrentLocation = (location: Location) => ({
   type: LOCATION_CHANGED,
   payload: location
+});
+
+export const replaceRoutes = (routes: Object) => ({
+  type: REPLACE_ROUTES,
+  payload: {
+    routes: flattenRoutes(routes),
+    options: {
+      updateRoutes: true
+    }
+  }
+});
+
+export const didReplaceRoutes = () => ({
+  type: DID_REPLACE_ROUTES
 });

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -3,58 +3,81 @@
 import type { StoreCreator, Reducer, StoreEnhancer } from 'redux';
 import type { History } from 'history';
 
+import type { Location } from './types';
+
 import qs from 'query-string';
 
 import { POP } from './types';
-import { locationDidChange } from './actions';
+import { locationDidChange, didReplaceRoutes, replace } from './actions';
 
 import matchCache from './util/match-cache';
 
-type EnhancerArgs = {
-  routes: Object,
-  history: History,
-  matchRoute: Function
+type InitialState = {
+  router: Location
 };
-export default ({ routes, history, matchRoute }: EnhancerArgs) =>
-  (createStore: StoreCreator<*, *>) =>
-    (
-      userReducer: Reducer<*, *>,
-      initialState: Location,
-      enhancer: StoreEnhancer<*, *>
-    ) => {
-      const store = createStore(userReducer, initialState, enhancer);
 
-      history.listen((location, action) => {
-        matchCache.clear();
+type EnhancerArgs = {|
+  history: History,
+  matchRoute: Function,
+  createMatcher: Function
+|};
+export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
+  createStore: StoreCreator<*, *>
+) => (
+  userReducer: Reducer<*, *>,
+  initialState: InitialState,
+  enhancer: StoreEnhancer<*, *>
+) => {
+  let currentMatcher = matchRoute;
 
-        const match = matchRoute(location.pathname);
+  const store = createStore(userReducer, initialState, enhancer);
 
-        // Other actions come from the user, so they already have a
-        // corresponding queued navigation action.
-        if (action === 'POP') {
-          store.dispatch({
-            type: POP,
-            payload: {
-              // We need to parse the query here because there's no user-facing
-              // action creator for POP (where we usually parse query strings).
-              ...location,
-              ...match,
-              query: qs.parse(location.search)
-            }
-          });
+  // Replace the matcher when replacing routes
+  store.subscribe(() => {
+    const {
+      routes,
+      pathname,
+      search,
+      hash,
+      options: { updateRoutes } = {}
+    } = store.getState().router;
+    if (updateRoutes) {
+      currentMatcher = createMatcher(routes);
+      store.dispatch(didReplaceRoutes());
+      store.dispatch(replace({ pathname, search, hash }));
+    }
+  });
+
+  history.listen((location, action) => {
+    matchCache.clear();
+
+    const match = currentMatcher(location.pathname);
+
+    // Other actions come from the user, so they already have a
+    // corresponding queued navigation action.
+    if (action === 'POP') {
+      store.dispatch({
+        type: POP,
+        payload: {
+          // We need to parse the query here because there's no user-facing
+          // action creator for POP (where we usually parse query strings).
+          ...location,
+          ...match,
+          query: qs.parse(location.search)
         }
-
-        store.dispatch(
-          locationDidChange({
-            ...location,
-            ...match
-          })
-        );
       });
+    }
 
-      return {
-        ...store,
-        routes,
-        matchRoute
-      };
-    };
+    store.dispatch(
+      locationDidChange({
+        ...location,
+        ...match
+      })
+    );
+  });
+
+  return {
+    ...store,
+    matchRoute
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ import {
   REPLACE,
   GO,
   GO_BACK,
-  GO_FORWARD
+  GO_FORWARD,
+  REPLACE_ROUTES,
+  DID_REPLACE_ROUTES
 } from './types';
 
 import {
@@ -14,6 +16,7 @@ import {
   go,
   goBack,
   goForward,
+  replaceRoutes,
   initializeCurrentLocation
 } from './actions';
 
@@ -42,11 +45,14 @@ export {
   go,
   goBack,
   goForward,
+  replaceRoutes,
   // Public action types
   LOCATION_CHANGED,
   PUSH,
   REPLACE,
   GO,
   GO_FORWARD,
-  GO_BACK
+  GO_BACK,
+  REPLACE_ROUTES,
+  DID_REPLACE_ROUTES
 };

--- a/src/install.js
+++ b/src/install.js
@@ -10,35 +10,36 @@ import { default as matcherFactory } from './util/create-matcher';
 import validateRoutes from './util/validate-routes';
 import flattenRoutes from './util/flatten-routes';
 
-type InstallArgs = {
+type InstallArgs = {|
   routes: Object,
   history: History,
   location: Location,
   createMatcher?: Function
-};
+|};
 
-export default (
-  {
-    routes: nestedRoutes,
-    history,
-    location,
-    createMatcher = matcherFactory
-  }: InstallArgs
-) => {
+export default ({
+  routes: nestedRoutes,
+  history,
+  location,
+  createMatcher = matcherFactory
+}: InstallArgs) => {
   validateRoutes(nestedRoutes);
   const routes = flattenRoutes(nestedRoutes);
   const matchRoute = createMatcher(routes);
 
   return {
     reducer: reducer({
-      ...location,
-      ...matchRoute(location.pathname)
+      routes,
+      initialLocation: {
+        ...location,
+        ...matchRoute(location.pathname)
+      }
     }),
     middleware: middleware({ history }),
     enhancer: enhancer({
-      routes,
       history,
-      matchRoute
+      matchRoute,
+      createMatcher
     })
   };
 };

--- a/src/types.js
+++ b/src/types.js
@@ -5,18 +5,22 @@ export type Query = { [key: string]: string };
 export type Params = { [key: string]: string };
 
 export type LocationOptions = {
-  persistQuery?: boolean
+  persistQuery?: boolean,
+  updateRoutes?: boolean
 };
 
-export type Location = $Shape<HistoryLocation & {
-  basename?: string,
-  options?: LocationOptions,
-  params?: Params,
-  previous?: Location,
-  query?: Query,
-  result?: Object,
-  queue?: Array<Location>
-}>;
+export type Location = $Shape<
+  HistoryLocation & {
+    basename?: string,
+    options?: LocationOptions,
+    params?: Params,
+    previous?: Location,
+    query?: Query,
+    result?: Object,
+    routes?: Object,
+    queue?: Array<Location>
+  }
+>;
 
 export type Href = string | Location;
 
@@ -27,6 +31,8 @@ export const GO = 'ROUTER_GO';
 export const GO_BACK = 'ROUTER_GO_BACK';
 export const GO_FORWARD = 'ROUTER_GO_FORWARD';
 export const POP = 'ROUTER_POP';
+export const REPLACE_ROUTES = 'ROUTER_REPLACE_ROUTES';
+export const DID_REPLACE_ROUTES = 'ROUTER_DID_REPLACE_ROUTES';
 
 export const isNavigationAction = (action: { type: $Subtype<string> }) =>
   [PUSH, REPLACE, GO, GO_BACK, GO_FORWARD, POP].indexOf(action.type) !== -1;

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -7,7 +7,8 @@ import {
   GO,
   GO_BACK,
   GO_FORWARD,
-  LOCATION_CHANGED
+  LOCATION_CHANGED,
+  DID_REPLACE_ROUTES
 } from '../src/types';
 
 import {
@@ -16,6 +17,8 @@ import {
   go,
   goBack,
   goForward,
+  replaceRoutes,
+  didReplaceRoutes,
   locationDidChange,
   initializeCurrentLocation
 } from '../src/actions';
@@ -75,6 +78,28 @@ describe('Action creators', () => {
 
   it('creates a GO_FORWARD action', () => {
     expect(goForward()).to.deep.equal({ type: GO_FORWARD });
+  });
+
+  it('creates a REPLACE_ROUTES action with flattened route payloads and options', () => {
+    const routes = { '/': { '/this': { '/is': { '/nested': '' } } } };
+    const action = replaceRoutes(routes);
+    expect(action).to.have.nested.property('payload.routes');
+    expect(action.payload.routes).to.have.all.keys(
+      '/',
+      '/this',
+      '/this/is',
+      '/this/is/nested'
+    );
+    expect(action).to.have.nested.property(
+      'payload.options.updateRoutes',
+      true
+    );
+  });
+
+  it('creates a DID_REPLACE_ROUTES action', () => {
+    expect(didReplaceRoutes()).to.deep.equal({
+      type: DID_REPLACE_ROUTES
+    });
   });
 
   it('combines the location descriptor and the route match into a LOCATION_CHANGED action', () => {

--- a/test/install.spec.js
+++ b/test/install.spec.js
@@ -20,6 +20,11 @@ describe('Router installer', () => {
         thing: 'stuff'
       },
       route: '/:thing',
+      routes: {
+        '/:thing': {
+          congratulations: 'you played yourself'
+        }
+      },
       result: {
         congratulations: 'you played yourself'
       },
@@ -33,7 +38,8 @@ describe('Router installer', () => {
         routes: null,
         history: {},
         location: {}
-      })).to.throw(Error);
+      })
+    ).to.throw(Error);
   });
 
   it('throws if malformed routes are provided', () => {
@@ -46,6 +52,7 @@ describe('Router installer', () => {
         },
         history: {},
         location: {}
-      })).to.throw(Error);
+      })
+    ).to.throw(Error);
   });
 });

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import { flow, partialRight } from 'lodash';
 import reducer from '../src/reducer';
-import { LOCATION_CHANGED, PUSH } from '../src/types';
+import {
+  LOCATION_CHANGED,
+  PUSH,
+  REPLACE_ROUTES,
+  DID_REPLACE_ROUTES
+} from '../src/types';
 
 describe('Router reducer', () => {
   it('adds the pathname to the store', () => {
@@ -41,6 +46,7 @@ describe('Router reducer', () => {
       },
       query: {},
       queue: [],
+      routes: {},
       previous: {
         queue: [
           {
@@ -75,6 +81,7 @@ describe('Router reducer', () => {
       pathname: '/rofl',
       query: {},
       queue: [],
+      routes: {},
       previous: {
         pathname: '/waffle',
         queue: [{ pathname: '/rofl' }]
@@ -134,7 +141,8 @@ describe('Router reducer', () => {
         ]
       },
       query: {},
-      queue: []
+      queue: [],
+      routes: {}
     });
   });
 
@@ -193,7 +201,8 @@ describe('Router reducer', () => {
           }
         ]
       },
-      queue: []
+      queue: [],
+      routes: {}
     });
   });
 
@@ -262,7 +271,8 @@ describe('Router reducer', () => {
           }
         ]
       },
-      queue: []
+      queue: [],
+      routes: {}
     });
   });
 
@@ -307,7 +317,7 @@ describe('Router reducer', () => {
       }
     };
     const result = reducer()(undefined, action);
-    expect(result).to.deep.equal({ queue: [] });
+    expect(result).to.deep.equal({ routes: {}, queue: [] });
   });
 
   it('uses given location as initial state when no initial router state provided', () => {
@@ -319,10 +329,12 @@ describe('Router reducer', () => {
     };
 
     const result = reducer({
-      pathname: '/lol',
-      search: '?as=af',
-      query: {
-        as: 'af'
+      initialLocation: {
+        pathname: '/lol',
+        search: '?as=af',
+        query: {
+          as: 'af'
+        }
       }
     })(undefined, action);
 
@@ -332,7 +344,43 @@ describe('Router reducer', () => {
       query: {
         as: 'af'
       },
-      queue: []
+      queue: [],
+      routes: {}
     });
+  });
+
+  it('replaces routes', () => {
+    const reducerInstance = reducer({
+      routes: { '/': { pied: 'piper' } },
+      pathname: '/bachmanity'
+    });
+
+    const replaceRoutesAction = {
+      type: REPLACE_ROUTES,
+      payload: {
+        routes: { '/hoo': 'li' },
+        options: { updateRoutes: true }
+      }
+    };
+
+    const didReplaceRoutesAction = { type: DID_REPLACE_ROUTES };
+
+    flow(
+      partialRight(reducerInstance, replaceRoutesAction),
+      state => {
+        expect(state).to.have.deep.nested.property('routes', { '/hoo': 'li' });
+        expect(state).to.have.deep.nested.property(
+          'options.updateRoutes',
+          true
+        );
+        return state;
+      },
+      partialRight(reducerInstance, didReplaceRoutesAction),
+      state => {
+        expect(state).to.have.deep.nested.property('routes', { '/hoo': 'li' });
+        expect(state).to.not.have.deep.nested.property('options.updateRoutes');
+        return state;
+      }
+    )({});
   });
 });


### PR DESCRIPTION
Adds a `replaceRoutes` action creator that allows for changing the formerly static top-level routes. This'll allow for code splitting for people who still prefer top-level routing vs. dynamic `Fragment` matching.