### PR TITLE
Parsing the query string on location change

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -71,7 +71,8 @@ export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
     store.dispatch(
       locationDidChange({
         ...location,
-        ...match
+        ...match,
+        query: qs.parse(location.search)
       })
     );
   });


### PR DESCRIPTION
This PR is intended to fix #211. 

Issue:

When navigating via the back button to a route which contains a query string, you will not receive a query object (parsed search string) in the payload.

Changes:

- [x] parses the search string in a similar manner as the `ROUTER_POP` action.