### PR TITLE
Include POP action type as a public action type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {
   GO,
   GO_BACK,
   GO_FORWARD,
+  POP,
   REPLACE_ROUTES,
   DID_REPLACE_ROUTES
 } from './types';
@@ -51,8 +52,9 @@ export {
   PUSH,
   REPLACE,
   GO,
-  GO_FORWARD,
   GO_BACK,
+  GO_FORWARD,
+  POP,
   REPLACE_ROUTES,
   DID_REPLACE_ROUTES
 };


### PR DESCRIPTION
This is a small PR which adds the `POP` (`ROUTER_POP`) action type to the public exports in `src/index.js`. Of all the types defined in `src/types.js`, this is the only one that was not included in the list of "public action types". 

From what I can tell, it's quite useful since it's the only action which fires for both router induced back behavior (e.g., `goBack()`) _and_ for browser induced back button (e.g., the browser's back button). 