### PR TITLE
Only enqueue payloads for navigation actions that have them

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,7 +7,7 @@ import {
   LOCATION_CHANGED,
   REPLACE_ROUTES,
   DID_REPLACE_ROUTES,
-  isNavigationAction
+  isNavigationActionWithPayload
 } from './types';
 
 const flow = (...funcs: Array<*>) =>
@@ -120,7 +120,7 @@ export default ({ routes = {}, initialLocation }: ReducerArgs = {}) => (
   state: Location = { ...initialLocation, routes, queue: [] },
   action: LocationAction
 ) => {
-  if (isNavigationAction(action)) {
+  if (isNavigationActionWithPayload(action)) {
     return {
       ...state,
       queue: state.queue && state.queue.concat([action.payload])

--- a/src/types.js
+++ b/src/types.js
@@ -34,8 +34,14 @@ export const POP = 'ROUTER_POP';
 export const REPLACE_ROUTES = 'ROUTER_REPLACE_ROUTES';
 export const DID_REPLACE_ROUTES = 'ROUTER_DID_REPLACE_ROUTES';
 
+const actionsWithPayload = [PUSH, REPLACE, GO, POP];
+const actions = [...actionsWithPayload, GO_FORWARD, GO_BACK, POP];
+
 export const isNavigationAction = (action: { type: $Subtype<string> }) =>
-  [PUSH, REPLACE, GO, GO_BACK, GO_FORWARD, POP].indexOf(action.type) !== -1;
+  actions.indexOf(action.type) !== -1;
+
+export const isNavigationActionWithPayload = (action: { type: $Subtype<string> }) =>
+  actionsWithPayload.indexOf(action.type) !== -1;
 
 export type BareAction = {
   type: 'ROUTER_GO_BACK' | 'ROUTER_GO_FORWARD'

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -5,7 +5,10 @@ import {
   LOCATION_CHANGED,
   PUSH,
   REPLACE_ROUTES,
-  DID_REPLACE_ROUTES
+  DID_REPLACE_ROUTES,
+  GO_BACK,
+  GO_FORWARD,
+  REPLACE
 } from '../src/types';
 
 describe('Router reducer', () => {
@@ -349,7 +352,7 @@ describe('Router reducer', () => {
     });
   });
 
-  it('replaces routes', () => {
+it('replaces routes', () => {
     const reducerInstance = reducer({
       routes: { '/': { pied: 'piper' } },
       pathname: '/bachmanity'
@@ -382,5 +385,20 @@ describe('Router reducer', () => {
         return state;
       }
     )({});
+  });
+
+  it('should only enqueue navigation actions with payloads', () => {
+    const reducerInstance = reducer();
+    const result = flow(
+      partialRight(reducerInstance, { type: GO_BACK }),
+      partialRight(reducerInstance, { type: GO_FORWARD }),
+      partialRight(reducerInstance, { type: REPLACE, payload: { pathname: '/lolk' } }),
+      partialRight(reducerInstance, { type: GO_FORWARD }),
+      partialRight(reducerInstance, { type: GO_BACK }),
+    )(undefined);
+    expect(result).to.deep.equal({
+      routes: {},
+      queue: [{ pathname: '/lolk' }]
+    });
   });
 });


### PR DESCRIPTION
This is the first half of the fix(es) that I outlined in https://github.com/FormidableLabs/redux-little-router/issues/211

* Implement `isNavigationActionWithPayload` 
* Define `actionsWithPayload` and `actions` instead of inlining the arrays in `isNavigationAction{WithPayload}`


