### PR TITLE
Include parsed query in all history listener dispatches

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -52,28 +52,20 @@ export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
     matchCache.clear();
 
     const match = currentMatcher(location.pathname);
-
+    const payload = {
+      ...location,
+      ...match,
+      query: qs.parse(location.search)
+    };
     // Other actions come from the user, so they already have a
     // corresponding queued navigation action.
     if (action === 'POP') {
       store.dispatch({
         type: POP,
-        payload: {
-          // We need to parse the query here because there's no user-facing
-          // action creator for POP (where we usually parse query strings).
-          ...location,
-          ...match,
-          query: qs.parse(location.search)
-        }
+        payload
       });
     }
-
-    store.dispatch(
-      locationDidChange({
-        ...location,
-        ...match
-      })
-    );
+    store.dispatch(locationDidChange(payload));
   });
 
   return {


### PR DESCRIPTION
Second part of the fix outlined in https://github.com/FormidableLabs/redux-little-router/issues/211#issuecomment-338770696


@tptee I couldn't figure out an easy way to test this. `enhancer.spec.js` is mocking `dispatch` for the store created by the `createStore` call in the test file, but it isn't mocking the store that's creating [inside the enhancer](https://github.com/FormidableLabs/redux-little-router/blob/master/src/enhancer.js#L33). To test this we'd probably want to somehow mock that internal store and assert that it's dispatching the correct payload for `POP` actions, but I can't figure out a clean way to do that 🤔  That `history.listen` callback depends on the dynamic `currentMatcher` variable in the parent scope so refactoring is kind of tricky.