### PR TITLE
Refactor enhancer store subscriber and history listener

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -30,10 +30,11 @@ export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
 ) => {
   let currentMatcher = matchRoute;
 
-  const store = createStore(userReducer, initialState, enhancer);
-
-  // Replace the matcher when replacing routes
-  store.subscribe(() => {
+export const createStoreSubscriber = (
+  store: Store<*, *>,
+  createMatcher: Function
+) => {
+  return (currentMatcher: Function) => {
     const {
       routes,
       pathname,
@@ -46,7 +47,9 @@ export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
       store.dispatch(didReplaceRoutes());
       store.dispatch(replace({ pathname, search, hash }));
     }
-  });
+    return currentMatcher;
+  };
+};
 
   history.listen((location, action) => {
     matchCache.clear();
@@ -66,6 +69,17 @@ export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
       });
     }
     store.dispatch(locationDidChange(payload));
+export default ({ history, matchRoute, createMatcher }: EnhancerArgs) => (
+  createStore: StoreCreator<*, *>
+) => (
+  userReducer: Reducer<*, *>,
+  initialState: InitialState,
+  enhancer: StoreEnhancer<*, *>
+) => {
+  let currentMatcher = matchRoute;
+
+  const store = createStore(userReducer, initialState, enhancer);
+  const storeSubscriber = createStoreSubscriber(store, createMatcher);
   });
 
   return {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -45,7 +45,7 @@ export const createStoreSubscriber = (
 
 
 export const createHistoryListener = (store: Store<*, *>) => (
-  currentMatcher,
+  currentMatcher: Function,
   location: HistoryLocation,
   action?: Action
 ) => {

--- a/test/enhancer.spec.js
+++ b/test/enhancer.spec.js
@@ -3,9 +3,11 @@ import sinonChai from 'sinon-chai';
 
 import { combineReducers, compose, createStore, applyMiddleware } from 'redux';
 
-import { PUSH, REPLACE_ROUTES } from '../src/types';
+import { PUSH, REPLACE_ROUTES, POP } from '../src/types';
+import {locationDidChange, didReplaceRoutes, replace} from '../src/actions';
 import install from '../src/install';
 import createMatcher from '../src/util/create-matcher';
+import {createHistoryListener, createStoreSubscriber} from '../src/enhancer';
 
 import defaultRoutes from './test-util/fixtures/routes';
 
@@ -21,8 +23,8 @@ describe('Router store enhancer', () => {
 
     const listen = sandbox.spy(cb => cb({ pathname: '/' }));
     const push = sandbox.spy(() => listen(listenStub));
-    const replace = sandbox.spy(() => listen(listenStub));
-    historyStub = { push, replace, listen };
+    const replaceStub = sandbox.spy(() => listen(listenStub));
+    historyStub = { push, replace: replaceStub, listen };
 
     const { reducer, middleware, enhancer } = install({
       routes: defaultRoutes,
@@ -74,6 +76,67 @@ describe('Router store enhancer', () => {
     const matcher = createMatcher(routes);
     expect(matcher('/')).to.have.deep.property('result', {
       could: 'you not'
+    });
+  });
+
+  describe('createHistoryListener', () => {
+    let historyListener;
+    let currentMatcher;
+    let storeStub;
+
+    beforeEach(() => {
+      storeStub = {
+        dispatch: sandbox.spy()
+      };
+      // Mock the matcher by just returning a object with a single
+      // `route` field populated with the pathname.
+      // eslint-disable-next-line max-nested-callbacks
+      currentMatcher = sandbox.spy((pathname) => ({ route: pathname }));
+      historyListener = createHistoryListener(storeStub);
+    });
+
+    it('should call currentMatcher with the pathname', () => {
+      historyListener(
+        currentMatcher,
+        { pathname: '/lol/k' },
+        PUSH
+      );
+      expect(currentMatcher).to.have.been.calledOnce;
+      expect(currentMatcher).to.have.been.calledWith('/lol/k');
+    });
+
+    it('should dispatch a LOCATION_CHANGED action', () => {
+      historyListener(
+        currentMatcher,
+        { pathname: '/lol/k', search: '?foo=bar' },
+        PUSH
+      );
+      expect(storeStub.dispatch).to.have.been.calledOnce;
+      expect(storeStub.dispatch).to.have.been.calledWith(locationDidChange({
+        pathname: '/lol/k',
+        route: '/lol/k',
+        query: { foo: 'bar' },
+        search: '?foo=bar'
+      }));
+    });
+
+    it('should dispatch a POP action for POP events', () => {
+      historyListener(
+        currentMatcher,
+        { pathname: '/lol/k', search: '?foo=bar' },
+        "POP"
+      );
+      // eslint-disable-next-line no-magic-numbers
+      expect(storeStub.dispatch).to.have.been.calledTwice;
+      expect(storeStub.dispatch.getCall(0).args[0]).to.deep.equal({
+        type: POP,
+        payload: {
+          pathname: '/lol/k',
+          route: '/lol/k',
+          query: { foo: 'bar' },
+          search: '?foo=bar'
+        }
+      });
     });
   });
 });

--- a/test/enhancer.spec.js
+++ b/test/enhancer.spec.js
@@ -139,4 +139,48 @@ describe('Router store enhancer', () => {
       });
     });
   });
+
+  describe('createStoreSubscriber', () => {
+    let routerState;
+    let storeStub;
+    let currentMatcher;
+    let storeSubscriber;
+    /* eslint-disable max-nested-callbacks */
+    beforeEach(() => {
+      routerState = {};
+      storeStub = {
+        dispatch: sandbox.spy(),
+        getState: sandbox.spy(() => ({ router: routerState }))
+      };
+      const createMatcherStub = sandbox.spy(routes => routes);
+      // The matcher stub is just an empty object that acts as a sigil
+      currentMatcher = {};
+      storeSubscriber = createStoreSubscriber(storeStub, createMatcherStub);
+    });
+    /* eslint-enable max-nested-callbacks */
+    it('should not update routes if updateRoutes is not true', () => {
+      const newRoutes = {};
+      routerState = {
+        routes: newRoutes
+      };
+      expect(storeSubscriber(currentMatcher)).to.equal(currentMatcher);
+      expect(storeStub.dispatch).not.to.have.been.called;
+    })
+
+    it('should update routes if updateRoutes is true', () => {
+      const newRoutes = {};
+      const routeInfo = { pathname: '/lol/k', search: '?what=yeah', hash: '#' };
+      routerState = {
+        ...routeInfo,
+        routes: newRoutes,
+        options: { updateRoutes: true }
+      };
+      expect(storeSubscriber(currentMatcher)).to.equal(newRoutes);
+      expect(storeStub.dispatch).to.have.been.calledTwice;
+      expect(storeStub.dispatch.getCall(0).args[0]).to.deep.equal(didReplaceRoutes());
+      expect(storeStub.dispatch.getCall(1).args[0]).to.deep.equal(replace(routeInfo));
+    })
+
+
+  });
 });


### PR DESCRIPTION
I had some trouble testing changes made to one of these callbacks in https://github.com/FormidableLabs/redux-little-router/pull/240, so here's a small refactor that makes them a bit more testable. This PR:

* Stops defining the callbacks as inline arrow functions and implements `createStoreSubscriber` and `createHistoryListener` instead. These functions accept some constant dependencies (like `store`) and return functions that can be called with the dynamic values like `currentMatcher`

* Adds tests for both of those new functions

I'm not sure it's the _best_ solution but it seems sufficient to me 🤷‍♂️ 