### PR TITLE
Make pathname optional in Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ export type LocationOptions = {
 export interface HistoryLocation {
   hash?: string,
   key?: string
-  pathname: string,
+  pathname?: string,
   search?: string,
   state?: ObjectLiteral<any>,
 }


### PR DESCRIPTION
Pathname is optional in that you can do the following and it will work correctly:
```typescript
dispatch(push({ query: { something: "value" }));
```

I've updated the typings to reflect this and to be inline with the typings that were previously available at `@types/redux-little-router`