### PR TITLE
Allow for options to be passed to UrlPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import yourReducer from './your-app';
 // Useful for page titles and other route-specific data.
 
 // Uses https://github.com/snd/url-pattern for URL matching
-// and parameter extraction.
+// and parameter extraction. Options for 'url-pattern' can be set in patternOptions
 const routes = {
   '/messages': {
     title: 'Message'
@@ -64,7 +64,8 @@ const routes = {
     '/bio': {
       title: 'Biographies',
       '/:name': {
-        title: 'Biography for:'
+        title: 'Biography for:',
+        patternOptions: {segmentValueCharset: 'a-zA-Z_'},
       }
     }
   }

--- a/src/util/create-matcher.js
+++ b/src/util/create-matcher.js
@@ -41,7 +41,7 @@ export default (routes: Object) => {
     .reverse()
     .map(route => ({
       route,
-      pattern: new UrlPattern(route),
+      pattern: new UrlPattern(route, routes[route].patternOptions || {}),
       result: routes[route]
     }));
 

--- a/test/test-util/fixtures/routes.js
+++ b/test/test-util/fixtures/routes.js
@@ -16,6 +16,10 @@ export default flattenRoutes({
   '/home/:spookyparam': {
     name: '3spooky5me'
   },
+  '/home/email/:customparam': {
+    name: 'custom',
+    patternOptions: { segmentValueCharset: 'a-zA-Z0-9-_~ %@.' }
+  },
   '/': {
     '/oh': {
       name: 'oh',

--- a/test/util/create-matcher.spec.js
+++ b/test/util/create-matcher.spec.js
@@ -70,5 +70,15 @@ describe('createMatcher', () => {
         name: '3spooky5me'
       }
     });
+
+    expect(matchRoute('/home/email/doot@dootmail.com')).to.deep.equal({
+      route: '/home/email/:customparam',
+      params: {
+        customparam: 'doot@dootmail.com'
+      },
+      result: {
+        name: 'custom'
+      }
+    });
   });
 });


### PR DESCRIPTION
We needed to be able to pass in options to UrlPattern to allow for dots in variable names.