### PR TITLE
Include hash in stringify-href to allow hashes in new tabs/windows

### DIFF
--- a/src/util/stringify-href.js
+++ b/src/util/stringify-href.js
@@ -6,6 +6,6 @@ export default (href: Href, basename: ?string) => {
     return `${basename || ''}${href}`;
   }
 
-  const { pathname, search } = href;
-  return `${basename || ''}${pathname}${search || ''}`;
+  const { pathname, search, hash } = href;
+  return `${basename || ''}${pathname}${hash || ''}${search || ''}`;
 };


### PR DESCRIPTION
When there is a hash in the href and a user right-clicks to open the link in the new tab, the hash isn't included in the url. This can be very hard for users to find what they are looking for if you rely on hashes to jump to content in a new tab.